### PR TITLE
CI and Releases: Windows build artifacts + tagged release packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
-          include-prerelease: true
-
       - name: Restore
         shell: pwsh
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
-          include-prerelease: true
 
       - name: Restore
         shell: pwsh
@@ -37,16 +36,17 @@ jobs:
           dotnet publish .\src\FCS.csproj -c Release --no-build
 
       - name: Create ZIP archive
+        id: zip
         shell: pwsh
         run: |
           $publishDir = "src\bin\Release\net10.0-windows\win-x64\publish\"
           $zipPath = Join-Path $env:RUNNER_TEMP ("WT-FCSGenerator-" + $env:GITHUB_REF_NAME + "-windows-x64.zip")
           Compress-Archive -Path (Join-Path $publishDir '*') -DestinationPath $zipPath -Force
-          Write-Output "ZIP_PATH=$zipPath" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "zip_path=$zipPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Upload release asset
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ env.ZIP_PATH }}
+          files: ${{ steps.zip.outputs.zip_path }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR sets up CI and release automation for WT-FCSGenerator.

What’s included:
- CI (GitHub Actions):
  - Builds on push/PR to `dev` (and feature branches)
  - Publishes the app (Release) and uploads the `publish` folder as a workflow artifact
- Releases:
  - On pushing a tag like `vX.Y.Z`, builds and publishes, zips the publish output, and attaches it to a GitHub Release

Notes:
- Targets .NET 10 preview on `windows-latest` using `actions/setup-dotnet` with `include-prerelease: true` to match the project’s `net10.0-windows`.
- The project already copies assets from `assets/` into the publish output, so the release zip includes `FCS.exe` plus `Ballistic/`, `Data/`, `Datamine/`, `Localization/`, and `UserSights`/`Usersights`.
- Future enhancements can add Linux/Mac builds (for tooling parts) or produce self-contained builds if desired.

Try it:
- CI: push to `dev` or open a PR into `dev`.
- Release: create and push a tag, e.g. `v1.0.0`.
