### PR TITLE
CI: guard releases to main, zip via action, split jobs; docs: runtime note

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Updated version of the sight generation tool by  [Assin127](https://live.warthun
 
 - Get the latest Windows build from GitHub [Releases](https://github.com/tsvl/WT-FCSGenerator/releases).
 - Download the newest ZIP, extract it anywhere, and run `FCS.exe`.
+  - Requires the Microsoft .NET Desktop Runtime (framework‑dependent build; currently targeting .NET 10). If you don’t have it installed, grab it from the [.NET downloads page](https://dotnet.microsoft.com/download/dotnet).
 
 ## Quick start (most users)
 


### PR DESCRIPTION
Summary
- Add guard: release tags must point to main (preflight job)
- Split workflow into build (Windows) and release (Ubuntu) jobs; pass publish output via artifact
- Replace ad-hoc PowerShell zip with a maintained action (thedoctor0/zip-release)
- Enable NuGet caching and allow preview SDK resolution in setup-dotnet
- Generate release notes automatically
- Docs: note that the app is framework-dependent and requires the .NET Desktop Runtime

Why
- Prevent accidental releases from non-main commits
- Improve reliability and readability of packaging
- Reproducible, cache-accelerated builds
- Clear expectations for users re: runtime requirement

Notes about workflow file
Due to GitHub token limitations for workflow file updates via this agent, this PR currently includes the README change only. Below is the exact release.yml content to apply on top of this branch (or I can push it if provided a token with `workflow` scope):

```yaml
name: Release

permissions:
  contents: read

on:
  push:
    tags:
      - 'v*.*.*'
  workflow_dispatch:
    inputs:
      version:
        description: 'Version tag (e.g., v2.0.0)'
        required: false

concurrency:
  group: releases
  cancel-in-progress: false

jobs:
  preflight:
    name: "Guard: tag must point to main"
    runs-on: ubuntu-latest
    steps:
      - name: Checkout (full history)
        uses: actions/checkout@v4
        with:
          fetch-depth: 0
      - name: Verify tag commit is on main
        run: |
          git fetch origin main --prune
          if ! git merge-base --is-ancestor "$GITHUB_SHA" "origin/main"; then
            echo "Tag commit ($GITHUB_SHA) is not reachable from origin/main. Aborting release." >&2
            exit 1
          fi

  build-windows:
    name: Build (Windows)
    needs: preflight
    runs-on: windows-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v4

      - name: Setup .NET
        uses: actions/setup-dotnet@v4
        with:
          dotnet-version: '10.0.x'
          include-prerelease: true
          cache: true

      - name: Restore
        shell: pwsh
        run: |
          dotnet restore .\src\FCS.csproj

      - name: Build
        shell: pwsh
        run: |
          dotnet build .\src\FCS.csproj -c Release --no-restore

      - name: Publish
        shell: pwsh
        run: |
          dotnet publish .\src\FCS.csproj -c Release --no-build

      - name: Upload publish as artifact
        uses: actions/upload-artifact@v4
        with:
          name: publish-windows-x64
          path: |
            src\bin\Release\net10.0-windows\win-x64\publish\

  release:
    name: Create GitHub Release
    needs: build-windows
    runs-on: ubuntu-latest
    permissions:
      contents: write
    steps:
      - name: Download artifact
        uses: actions/download-artifact@v4
        with:
          name: publish-windows-x64
          path: dist

      - name: Zip release
        uses: thedoctor0/zip-release@v0.7.6
        with:
          type: zip
          filename: WT-FCSGenerator-${{ github.ref_name }}-windows-x64.zip
          directory: ./
          path: dist/*

      - name: Publish GitHub Release
        uses: softprops/action-gh-release@v2
        with:
          files: WT-FCSGenerator-${{ github.ref_name }}-windows-x64.zip
          generate_release_notes: true
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

Acceptance
- After merge to main, pushing a tag vX.Y.Z (that points to main) should:
  - Build/publish on Windows
  - Zip the publish output
  - Create a GitHub Release with the zip asset and generated notes
- Tags not on main will fail fast in the guard job

Happy to split this into two PRs if you want docs separate from CI.
