### PR TITLE
docs: update README with new UserSights locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated pregenerated data files for War Thunder 2.53.0.19 (Line of Contact)
 
+### Changed
+
+- Updated README to reflect new `UserSights` folder locations as of War Thunder 2.53 Line of Contact update.
+
 ## [2.1.2] - 2025-11-22
 
 ### Added
@@ -101,7 +105,7 @@ Project cleanup and modernization. Builds now distributed via GitHub Releases, u
 Original release by [Assin127](https://live.warthunder.com/user/58909037/). Last version before project was taken over for maintenance and cleanup.
 
 <!-- Versions -->
-
+[2.1.3]: https://github.com/tsvl/WT-FCSGenerator/releases/tag/v2.1.3
 [2.1.2]: https://github.com/tsvl/WT-FCSGenerator/releases/tag/v2.1.2
 [2.1.1]: https://github.com/tsvl/WT-FCSGenerator/releases/tag/v2.1.1
 [2.1.0]: https://github.com/tsvl/WT-FCSGenerator/releases/tag/v2.1.0

--- a/README.md
+++ b/README.md
@@ -10,10 +10,17 @@ Updated version of the sight generation tool by  [Assin127](https://live.warthun
 
 ## Quick start
 
+>[!IMPORTANT]
+> The game `UserSights` folder has been relocated as of the 2.53 Line of Contact update. According to the [changelog](https://warthunder.com/en/game/changelog/current/1806), custom sights should now be placed in:
+>
+> - Windows: `Documents\My Games\War Thunder\saves\{user id}\production\UserSights`
+> - Linux: `$HOME/.config/WarThunder/Saves/{user id}/production/UserSights`
+> - macOS: `Users/{user name}/My Games/War Thunder/saves/{user id}/production/UserSights`
+
   1. Run `FCS.exe`.
   2. Select language, sight type, and any options you want. The default paths are fine—no changes required.
   3. Click the "Make Sights" button.
-  4. Copy the output files from the `UserSights` folder next to `FCS.exe` into your War Thunder install’s `UserSights` folder (e.g., `C:\Program Files (x86)\Steam\steamapps\common\War Thunder\UserSights`).
+  4. Copy the output files from the `UserSights` folder next to `FCS.exe` into the War Thunder `UserSights` folder.
      - Optional: you can set the output path in FCS settings directly to the game’s `UserSights` folder to skip the copy step.
 
 >[!NOTE]


### PR DESCRIPTION
Update the README to reflect the new locations of the `UserSights` folder following the War Thunder 2.53 Line of Contact update.