### PR TITLE
feat: add convert command and corpus failure logging

### DIFF
--- a/tools/fcsgen/Cargo.lock
+++ b/tools/fcsgen/Cargo.lock
@@ -3,6 +3,102 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,6 +108,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "fcsgen"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "fcsgen-core",
 ]
 
@@ -31,6 +128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "indexmap"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +142,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -51,6 +160,12 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "proc-macro2"
@@ -115,6 +230,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +271,27 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/tools/fcsgen/cli/Cargo.toml
+++ b/tools/fcsgen/cli/Cargo.toml
@@ -16,3 +16,4 @@ workspace = true
 
 [dependencies]
 fcsgen-core = { path = "../core" }
+clap = { version = "4", features = ["derive"] }

--- a/tools/fcsgen/cli/src/main.rs
+++ b/tools/fcsgen/cli/src/main.rs
@@ -2,10 +2,112 @@
 //!
 //! See `docs/cli-stage1.md` for the full CLI specification.
 
-use fcsgen_core::VERSION;
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use fcsgen_core::{convert_vehicle, emit_legacy_txt, VERSION};
+
+#[derive(Parser)]
+#[command(name = "fcsgen", version = VERSION, about = "War Thunder FCS generation tool")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Convert datamine to Data/*.txt format
+    Convert {
+        /// Input directory containing extracted datamine (aces.vromfs.bin_u)
+        #[arg(short, long)]
+        input: PathBuf,
+
+        /// Output directory for converted .txt files
+        #[arg(short, long)]
+        output: PathBuf,
+
+        /// Only convert specific vehicle(s) by name (without .blkx extension)
+        #[arg(long)]
+        vehicle: Option<Vec<String>>,
+    },
+}
 
 fn main() {
-    println!("fcsgen v{VERSION}");
-    println!();
-    println!("This is a placeholder. See docs/cli-stage1.md for planned functionality.");
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Convert { input, output, vehicle } => {
+            run_convert(&input, &output, vehicle.as_deref());
+        }
+    }
+}
+
+fn run_convert(input: &PathBuf, output: &PathBuf, filter: Option<&[String]>) {
+    // Input should be the aces.vromfs.bin_u directory itself
+    let tankmodels = input.join("gamedata").join("units").join("tankmodels");
+
+    if !tankmodels.exists() {
+        eprintln!("Error: tankmodels directory not found at {tankmodels:?}");
+        eprintln!("Expected structure: <input>/gamedata/units/tankmodels/");
+        eprintln!("(input should be the aces.vromfs.bin_u directory)");
+        std::process::exit(1);
+    }
+
+    // convert_vehicle expects the parent of aces.vromfs.bin_u
+    let datamine_root = input.parent().unwrap_or(input);
+
+    // Create output directory
+    if let Err(e) = std::fs::create_dir_all(output) {
+        eprintln!("Error: cannot create output directory: {e}");
+        std::process::exit(1);
+    }
+
+    // Collect vehicle files
+    let vehicles: Vec<_> = std::fs::read_dir(&tankmodels)
+        .expect("read tankmodels")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "blkx"))
+        .filter(|e| {
+            if let Some(filter) = filter {
+                let stem = e.path().file_stem().unwrap().to_string_lossy().to_string();
+                filter.iter().any(|f| f == &stem)
+            } else {
+                true
+            }
+        })
+        .collect();
+
+    let total = vehicles.len();
+    let mut converted = 0;
+    let mut failed = 0;
+
+    eprintln!("Converting {total} vehicles from {tankmodels:?}");
+    eprintln!("Output: {output:?}");
+    eprintln!();
+
+    for entry in &vehicles {
+        let path = entry.path();
+        let name = path.file_stem().unwrap().to_string_lossy();
+
+        match convert_vehicle(&path, datamine_root) {
+            Ok(data) => {
+                let txt = emit_legacy_txt(&data);
+                let out_path = output.join(format!("{name}.txt"));
+
+                if let Err(e) = std::fs::write(&out_path, &txt) {
+                    eprintln!("WRITE ERROR {name}: {e}");
+                    failed += 1;
+                } else {
+                    converted += 1;
+                }
+            }
+            Err(e) => {
+                eprintln!("CONVERT ERROR {name}: {e}");
+                failed += 1;
+            }
+        }
+    }
+
+    eprintln!();
+    eprintln!("Done: {converted} converted, {failed} failed");
 }


### PR DESCRIPTION
This pull request introduces a real command-line interface to the `fcsgen` tool using the `clap` crate, replacing the previous placeholder implementation. It also significantly improves the test suite for vehicle conversion, adding a reusable comparison function and a comprehensive corpus test that checks all known vehicles and reports detailed statistics and failure logs.

**CLI Improvements:**

* Replaced the placeholder CLI in `main.rs` with a structured command-line interface using `clap`, supporting a `convert` subcommand with options for input/output directories and vehicle filtering.
* Added `clap` as a dependency in `Cargo.toml` to support the new CLI.

**Testing Enhancements:**

* Introduced a reusable `check_vehicle` function in the test suite to convert a single vehicle and compare its output to the expected result, providing detailed diff information on mismatches.
* Refactored the `test_bmp_2m_conversion` test to use the new `check_vehicle` function for improved clarity and maintainability.
* Added an ignored `test_full_corpus` test that runs conversion on all vehicles in the corpus, reports pass/fail/error statistics, logs the first 20 failures to the console, and writes a full failure report to disk. This enables comprehensive regression testing and easier debugging of conversion issues.

Resolves #22 