### PR TITLE
feat(fcsgen)!: add Stage 1 pipeline with vehicle and weapon parsers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,14 +3,6 @@
 # top-most EditorConfig file
 root = true
 
-# Default settings for all files
-[*]
-indent_style = space
-indent_size = 2
-end_of_line = lf
-charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true
 
 # C# files
 [*.cs]
@@ -45,7 +37,3 @@ dotnet_naming_symbols.private_fields.applicable_accessibilities = private
 
 dotnet_naming_style.underscore_prefix_style.capitalization = camel_case
 dotnet_naming_style.underscore_prefix_style.required_prefix = _
-
-# PowerShell files
-[*.{ps1,psm1,psd1}]
-charset = utf-8-bom

--- a/.gitignore
+++ b/.gitignore
@@ -444,6 +444,7 @@ FodyWeavers.xsd
 # Rust/Cargo build artifacts
 /tools/fcsgen/target/
 
+
 UserSights/
 !UserSights/.gitkeep
 Datamine/aces.vromfs.bin_u/gamedata/units/tankmodels/*
@@ -452,3 +453,5 @@ Datamine/aces.vromfs.bin_u/gamedata/weapons/groundmodels_weapons/*
 !Datamine/aces.vromfs.bin_u/gamedata/weapons/groundmodels_weapons/.gitkeep
 Datamine/lang.vromfs.bin_u/lang/*
 !Datamine/lang.vromfs.bin_u/lang/.gitkeep
+
+tools/fcsgen/test_data/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Introduced the Rust-based `fcsgen` Stage 1 pipeline (`tools/fcsgen`) with vehicle and weapon parsers, legacy emitters, and integration tests plus a `convert` CLI subcommand for datamine-to-`Data/*.txt` conversion (#34).
+
+### Fixed
+
+- Improved projectile parsing fidelity: APDS armor power series extraction, Cx array averaging, `/name/short` fallbacks, case-sensitive laser checks, and handling of modification `commonWeapons`, ATGM belts, rocket DeMarre values, and unarmed vehicles (stage 1 follow-ups for issue #19).
+
+### Changed
+
+- Added Rust formatting configuration so the new workspace adheres to repository style.
+
 ## [2.1.3] - 2025-12-20
 
 ### Added

--- a/tools/fcsgen/Cargo.lock
+++ b/tools/fcsgen/Cargo.lock
@@ -3,12 +3,298 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "fcsgen"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "fcsgen-core",
 ]
 
 [[package]]
 name = "fcsgen-core"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.148"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f4a4e8e9dc5c62d159f04fcdbe07f4c3fb710415aab4754bf11505501e3251d"

--- a/tools/fcsgen/Cargo.toml
+++ b/tools/fcsgen/Cargo.toml
@@ -1,17 +1,17 @@
 [workspace]
+members  = ["cli", "core"]
 resolver = "3"
-members = ["core", "cli"]
 
 [workspace.package]
-version = "0.1.0"
-edition = "2024"
+edition      = "2024"
+license      = "MIT"
+repository   = "https://github.com/tsvl/WT-FCSGenerator"
 rust-version = "1.92.0"
-license = "MIT"
-repository = "https://github.com/tsvl/WT-FCSGenerator"
+version      = "0.1.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
 
 [workspace.lints.clippy]
-all = { level = "warn", priority = -1 }
+all      = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }

--- a/tools/fcsgen/cli/Cargo.toml
+++ b/tools/fcsgen/cli/Cargo.toml
@@ -16,3 +16,4 @@ workspace = true
 
 [dependencies]
 fcsgen-core = { path = "../core" }
+clap = { version = "4", features = ["derive"] }

--- a/tools/fcsgen/cli/src/main.rs
+++ b/tools/fcsgen/cli/src/main.rs
@@ -2,10 +2,121 @@
 //!
 //! See `docs/cli-stage1.md` for the full CLI specification.
 
-use fcsgen_core::VERSION;
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use fcsgen_core::{VERSION, convert_vehicle, emit_legacy_txt};
+
+#[derive(Parser)]
+#[command(name = "fcsgen", version = VERSION, about = "War Thunder FCS generation tool")]
+struct Cli {
+	#[command(subcommand)]
+	command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+	/// Convert datamine to Data/*.txt format
+	Convert {
+		/// Input directory containing extracted datamine (aces.vromfs.bin_u)
+		#[arg(short, long)]
+		input: PathBuf,
+
+		/// Output directory for converted .txt files
+		#[arg(short, long)]
+		output: PathBuf,
+
+		/// Only convert specific vehicle(s) by name (without .blkx extension)
+		#[arg(long)]
+		vehicle: Option<Vec<String>>,
+	},
+}
 
 fn main() {
-    println!("fcsgen v{VERSION}");
-    println!();
-    println!("This is a placeholder. See docs/cli-stage1.md for planned functionality.");
+	let cli = Cli::parse();
+
+	match cli.command {
+		Commands::Convert {
+			input,
+			output,
+			vehicle,
+		} => {
+			run_convert(&input, &output, vehicle.as_deref());
+		},
+	}
+}
+
+fn run_convert(input: &PathBuf, output: &PathBuf, filter: Option<&[String]>) {
+	// Input should be the aces.vromfs.bin_u directory itself
+	let tankmodels = input.join("gamedata").join("units").join("tankmodels");
+
+	if !tankmodels.exists() {
+		eprintln!("Error: tankmodels directory not found at {tankmodels:?}");
+		eprintln!("Expected structure: <input>/gamedata/units/tankmodels/");
+		eprintln!("(input should be the aces.vromfs.bin_u directory)");
+		std::process::exit(1);
+	}
+
+	// convert_vehicle expects the parent of aces.vromfs.bin_u
+	let datamine_root = input.parent().unwrap_or(input);
+
+	// Create output directory
+	if let Err(e) = std::fs::create_dir_all(output) {
+		eprintln!("Error: cannot create output directory: {e}");
+		std::process::exit(1);
+	}
+
+	// Collect vehicle files
+	let vehicles: Vec<_> = std::fs::read_dir(&tankmodels)
+		.expect("read tankmodels")
+		.filter_map(|e| e.ok())
+		.filter(|e| e.path().extension().is_some_and(|ext| ext == "blkx"))
+		.filter(|e| {
+			if let Some(filter) = filter {
+				let stem = e.path().file_stem().unwrap().to_string_lossy().to_string();
+				filter.iter().any(|f| f == &stem)
+			} else {
+				true
+			}
+		})
+		.collect();
+
+	let total = vehicles.len();
+	let mut converted = 0;
+	let mut skipped = 0;
+	let mut failed = 0;
+
+	eprintln!("Converting {total} vehicles from {tankmodels:?}");
+	eprintln!("Output: {output:?}");
+	eprintln!();
+
+	for entry in &vehicles {
+		let path = entry.path();
+		let name = path.file_stem().unwrap().to_string_lossy();
+
+		match convert_vehicle(&path, datamine_root) {
+			Ok(data) if data.is_armed() => {
+				let txt = emit_legacy_txt(&data);
+				let out_path = output.join(format!("{name}.txt"));
+
+				if let Err(e) = std::fs::write(&out_path, &txt) {
+					eprintln!("WRITE ERROR {name}: {e}");
+					failed += 1;
+				} else {
+					converted += 1;
+				}
+			},
+			Ok(_) => {
+				// Unarmed vehicle (no projectiles found), skip output
+				skipped += 1;
+			},
+			Err(e) => {
+				eprintln!("CONVERT ERROR {name}: {e}");
+				failed += 1;
+			},
+		}
+	}
+
+	eprintln!();
+	eprintln!("Done: {converted} converted, {skipped} skipped (unarmed), {failed} failed");
 }

--- a/tools/fcsgen/core/Cargo.toml
+++ b/tools/fcsgen/core/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
-name = "fcsgen-core"
-description = "Core library for FCS generation — datamine parsing, ballistics, and sight rendering"
-version.workspace = true
-edition.workspace = true
+description            = "Core library for FCS generation — datamine parsing, ballistics, and sight rendering"
+edition.workspace      = true
+license.workspace      = true
+name                   = "fcsgen-core"
+repository.workspace   = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
+version.workspace      = true
 
 [lints]
 workspace = true
 
 [dependencies]
+serde      = { version = "1", features = ["derive"] }
+serde_json = { version = "1", features = ["preserve_order"] }
+thiserror  = "2"

--- a/tools/fcsgen/core/src/emit/legacy.rs
+++ b/tools/fcsgen/core/src/emit/legacy.rs
@@ -1,0 +1,207 @@
+//! Legacy Data/{vehicle}.txt format emitter.
+//!
+//! Produces the exact format expected by the existing WinForms tool's Stage 2 and 3.
+
+use std::fmt::Write;
+
+use crate::model::VehicleData;
+
+/// Format a float value, ensuring it always has a decimal point.
+/// E.g., 960 -> "960.0", 960.5 -> "960.5", 0.389 -> "0.389"
+fn fmt_float(v: f64) -> String {
+	let s = v.to_string();
+	if s.contains('.') { s } else { format!("{s}.0") }
+}
+
+/// Emit vehicle data in the legacy .txt format.
+///
+/// The format is:
+/// ```text
+/// WeaponPath:{path}
+/// RocketPath:{path}  (optional, up to 2)
+/// ZoomIn:{value}
+/// ZoomOut:{value}
+/// HasLaser  (optional, presence-only flag)
+///
+/// Name:{name}
+/// Type:{type}
+/// BulletMass:{value}
+/// ...
+/// ```
+pub fn emit_legacy_txt(data: &VehicleData) -> String {
+	let mut out = String::new();
+
+	// Header
+	if let Some(ref wp) = data.weapon_path {
+		writeln!(out, "WeaponPath:{wp}").unwrap();
+	}
+
+	for rp in &data.rocket_paths {
+		writeln!(out, "RocketPath:{rp}").unwrap();
+	}
+
+	if let Some(zi) = data.zoom_in {
+		writeln!(out, "ZoomIn:{}", fmt_float(zi)).unwrap();
+	}
+
+	if let Some(zo) = data.zoom_out {
+		writeln!(out, "ZoomOut:{}", fmt_float(zo)).unwrap();
+	}
+
+	if data.has_laser {
+		writeln!(out, "HasLaser").unwrap();
+	}
+
+	// Projectiles
+	for proj in &data.projectiles {
+		writeln!(out).unwrap(); // Blank line before each projectile block
+
+		writeln!(out, "Name:{}", proj.name).unwrap();
+		writeln!(out, "Type:{}", proj.bullet_type).unwrap();
+
+		if let Some(m) = proj.mass {
+			writeln!(out, "BulletMass:{}", fmt_float(m)).unwrap();
+		}
+
+		if let Some(bc) = proj.ballistic_caliber {
+			writeln!(out, "BallisticCaliber:{}", fmt_float(bc)).unwrap();
+		}
+
+		if let Some(s) = proj.speed {
+			writeln!(out, "Speed:{}", fmt_float(s)).unwrap();
+		}
+
+		// Cx with default of 0.38 (legacy behavior for rockets/ATGMs without Cx)
+		let cx = proj.cx.unwrap_or(0.38);
+		writeln!(out, "Cx:{}", fmt_float(cx)).unwrap();
+
+		if let Some(em) = proj.explosive_mass {
+			writeln!(out, "ExplosiveMass:{}", fmt_float(em)).unwrap();
+		}
+
+		if let Some(ref et) = proj.explosive_type {
+			writeln!(out, "ExplosiveType:{et}").unwrap();
+		}
+
+		if let Some(dm) = proj.damage_mass {
+			writeln!(out, "DamageMass:{}", fmt_float(dm)).unwrap();
+		}
+
+		if let Some(dc) = proj.damage_caliber {
+			writeln!(out, "DamageCaliber:{}", fmt_float(dc)).unwrap();
+		}
+
+		if let Some(ref demarre) = proj.demarre {
+			writeln!(out, "demarrePenetrationK:{}", fmt_float(demarre.k)).unwrap();
+			writeln!(out, "demarreSpeedPow:{}", fmt_float(demarre.speed_pow)).unwrap();
+			writeln!(out, "demarreMassPow:{}", fmt_float(demarre.mass_pow)).unwrap();
+			writeln!(out, "demarreCaliberPow:{}", fmt_float(demarre.caliber_pow)).unwrap();
+		}
+
+		if let Some(ap) = proj.armor_power {
+			writeln!(out, "ArmorPower:{}", fmt_float(ap)).unwrap();
+		}
+
+		// APDS armor power series (legacy field names)
+		if let Some(ref series) = proj.armor_power_series {
+			if let Some(v) = series.ap_0m {
+				writeln!(out, "APDS0:{}", fmt_float(v)).unwrap();
+			}
+			if let Some(v) = series.ap_100m {
+				writeln!(out, "APDS100:{}", fmt_float(v)).unwrap();
+			}
+			if let Some(v) = series.ap_500m {
+				writeln!(out, "APDS500:{}", fmt_float(v)).unwrap();
+			}
+			if let Some(v) = series.ap_1000m {
+				writeln!(out, "APDS1000:{}", fmt_float(v)).unwrap();
+			}
+			if let Some(v) = series.ap_1500m {
+				writeln!(out, "APDS1500:{}", fmt_float(v)).unwrap();
+			}
+			if let Some(v) = series.ap_2000m {
+				writeln!(out, "APDS2000:{}", fmt_float(v)).unwrap();
+			}
+			if let Some(v) = series.ap_2500m {
+				writeln!(out, "APDS2500:{}", fmt_float(v)).unwrap();
+			}
+			if let Some(v) = series.ap_3000m {
+				writeln!(out, "APDS3000:{}", fmt_float(v)).unwrap();
+			}
+			if let Some(v) = series.ap_3500m {
+				writeln!(out, "APDS3500:{}", fmt_float(v)).unwrap();
+			}
+			if let Some(v) = series.ap_4000m {
+				writeln!(out, "APDS4000:{}", fmt_float(v)).unwrap();
+			}
+			if let Some(v) = series.ap_4500m {
+				writeln!(out, "APDS4500:{}", fmt_float(v)).unwrap();
+			}
+			if let Some(v) = series.ap_10000m {
+				writeln!(out, "APDS10000:{}", fmt_float(v)).unwrap();
+			}
+		}
+	}
+
+	// Legacy format doesn't have trailing newline
+	out.trim_end().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::model::{DemarreParams, Projectile};
+
+	#[test]
+	fn test_emit_basic() {
+		let data = VehicleData {
+			id: "test_vehicle".to_string(),
+			weapon_path: Some("gameData/Weapons/test.blkx".to_string()),
+			rocket_paths: vec![],
+			zoom_in: Some(6.0),
+			zoom_out: Some(30.0),
+			zoom_in_2: None,
+			zoom_out_2: None,
+			has_laser: true,
+			projectiles: vec![Projectile {
+				name: "test_shell".to_string(),
+				bullet_type: "ap_t".to_string(),
+				mass: Some(10.0),
+				ballistic_caliber: Some(0.1),
+				speed: Some(800.0),
+				cx: Some(0.3),
+				explosive_mass: None,
+				explosive_type: None,
+				damage_mass: None,
+				damage_caliber: None,
+				demarre: Some(DemarreParams {
+					k: 0.9,
+					speed_pow: 1.43,
+					mass_pow: 0.71,
+					caliber_pow: 1.07,
+				}),
+				armor_power: None,
+				armor_power_series: None,
+			}],
+		};
+
+		let output = emit_legacy_txt(&data);
+
+		assert!(output.contains("WeaponPath:gameData/Weapons/test.blkx"));
+		assert!(output.contains("ZoomIn:6.0"));
+		assert!(output.contains("ZoomOut:30.0"));
+		assert!(output.contains("HasLaser"));
+		assert!(output.contains("Name:test_shell"));
+		assert!(output.contains("Type:ap_t"));
+		assert!(output.contains("BulletMass:10.0"));
+		assert!(output.contains("demarrePenetrationK:0.9"));
+	}
+
+	#[test]
+	fn test_fmt_float() {
+		assert_eq!(fmt_float(960.0), "960.0");
+		assert_eq!(fmt_float(960.5), "960.5");
+		assert_eq!(fmt_float(0.389), "0.389");
+		assert_eq!(fmt_float(1.0), "1.0");
+	}
+}

--- a/tools/fcsgen/core/src/emit/mod.rs
+++ b/tools/fcsgen/core/src/emit/mod.rs
@@ -1,0 +1,5 @@
+//! Emitters for output formats.
+
+pub mod legacy;
+
+pub use legacy::emit_legacy_txt;

--- a/tools/fcsgen/core/src/error.rs
+++ b/tools/fcsgen/core/src/error.rs
@@ -1,0 +1,53 @@
+//! Error types for FCS generation.
+
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// Result type alias using our error type.
+pub type Result<T> = std::result::Result<T, ParseError>;
+
+/// Errors that can occur during parsing or conversion.
+#[derive(Debug, Error)]
+pub enum ParseError {
+	/// Failed to read a file.
+	#[error("failed to read file {path}: {source}")]
+	IoError {
+		path: PathBuf,
+		#[source]
+		source: std::io::Error,
+	},
+
+	/// Failed to parse JSON.
+	#[error("failed to parse JSON in {path}: {source}")]
+	JsonError {
+		path: PathBuf,
+		#[source]
+		source: serde_json::Error,
+	},
+
+	/// Missing required field in datamine.
+	#[error("missing required field '{field}' in {context}")]
+	MissingField { field: String, context: String },
+
+	/// Invalid data format.
+	#[error("invalid data format in {context}: {message}")]
+	InvalidFormat { context: String, message: String },
+}
+
+impl ParseError {
+	/// Create an IO error with path context.
+	pub fn io(path: impl Into<PathBuf>, source: std::io::Error) -> Self {
+		Self::IoError {
+			path: path.into(),
+			source,
+		}
+	}
+
+	/// Create a JSON parse error with path context.
+	pub fn json(path: impl Into<PathBuf>, source: serde_json::Error) -> Self {
+		Self::JsonError {
+			path: path.into(),
+			source,
+		}
+	}
+}

--- a/tools/fcsgen/core/src/lib.rs
+++ b/tools/fcsgen/core/src/lib.rs
@@ -7,14 +7,85 @@
 //!
 //! See the CLI crate (`fcsgen`) for the command-line interface.
 
+pub mod emit;
+pub mod error;
+pub mod model;
+pub mod parser;
+
+pub use emit::emit_legacy_txt;
+pub use error::{ParseError, Result};
+pub use model::{Projectile, VehicleData};
+pub use parser::{parse_vehicle, parse_weapon_module};
+
+use std::path::Path;
+
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Convert a vehicle from datamine to legacy Data format.
+///
+/// This is the main entry point for Stage 1 conversion.
+///
+/// # Arguments
+/// * `vehicle_path` - Path to the vehicle .blkx file
+/// * `datamine_root` - Root path of the datamine (contains aces.vromfs.bin_u/)
+///
+/// # Returns
+/// A `VehicleData` struct with all header and projectile data.
+pub fn convert_vehicle(vehicle_path: &Path, datamine_root: &Path) -> Result<VehicleData> {
+	// Parse vehicle file
+	let vehicle_json = read_json_file(vehicle_path)?;
+	let vehicle_id = vehicle_path
+		.file_stem()
+		.and_then(|s| s.to_str())
+		.unwrap_or("unknown");
+
+	let mut data = parse_vehicle(&vehicle_json, vehicle_id)?;
+
+	// Parse weapon module and collect projectiles (pass vehicle JSON for belt filtering)
+	if let Some(ref weapon_path) = data.weapon_path {
+		let full_path = resolve_weapon_path(datamine_root, weapon_path);
+		if full_path.exists() {
+			let weapon_json = read_json_file(&full_path)?;
+			let projectiles = parse_weapon_module(&weapon_json, Some(&vehicle_json))?;
+			data.projectiles.extend(projectiles);
+		}
+	}
+
+	// Parse rocket modules and collect projectiles (pass vehicle JSON for belt filtering)
+	for rocket_path in data.rocket_paths.clone() {
+		let full_path = resolve_weapon_path(datamine_root, &rocket_path);
+		if full_path.exists() {
+			let rocket_json = read_json_file(&full_path)?;
+			let projectiles = parse_weapon_module(&rocket_json, Some(&vehicle_json))?;
+			data.projectiles.extend(projectiles);
+		}
+	}
+
+	Ok(data)
+}
+
+/// Read and parse a JSON file.
+fn read_json_file(path: &Path) -> Result<serde_json::Value> {
+	let content = std::fs::read_to_string(path).map_err(|e| ParseError::io(path, e))?;
+	serde_json::from_str(&content).map_err(|e| ParseError::json(path, e))
+}
+
+/// Resolve a weapon path relative to the datamine root.
+///
+/// Weapon paths in vehicle files look like "gameData/Weapons/..."
+/// and need to be resolved relative to the aces.vromfs.bin_u directory.
+fn resolve_weapon_path(datamine_root: &Path, weapon_path: &str) -> std::path::PathBuf {
+	// Normalize path separators and case for cross-platform compatibility
+	let normalized = weapon_path.replace('\\', "/").to_lowercase();
+	datamine_root.join("aces.vromfs.bin_u").join(&normalized)
+}
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn version_is_set() {
-        assert!(!VERSION.is_empty());
-    }
+	#[test]
+	fn version_is_set() {
+		assert!(!VERSION.is_empty());
+	}
 }

--- a/tools/fcsgen/core/src/model.rs
+++ b/tools/fcsgen/core/src/model.rs
@@ -1,0 +1,133 @@
+//! Data models for FCS generation.
+//!
+//! These structs represent the intermediate data extracted from datamine files,
+//! used for ballistic computation and sight generation.
+
+use serde::{Deserialize, Serialize};
+
+/// Complete vehicle data extracted from datamine, ready for emission.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VehicleData {
+	/// Vehicle identifier (basename of .blkx file, e.g. "ussr_bmp_2m").
+	pub id: String,
+
+	/// Path to the primary weapon module (e.g. "gameData/Weapons/groundModels_weapons/...").
+	pub weapon_path: Option<String>,
+
+	/// Paths to rocket/ATGM modules (up to 2).
+	pub rocket_paths: Vec<String>,
+
+	/// Primary optics zoom (narrow FOV, higher magnification).
+	pub zoom_in: Option<f64>,
+
+	/// Primary optics zoom (wide FOV, lower magnification).
+	pub zoom_out: Option<f64>,
+
+	/// Secondary optics zoom (narrow FOV), if present.
+	pub zoom_in_2: Option<f64>,
+
+	/// Secondary optics zoom (wide FOV), if present.
+	pub zoom_out_2: Option<f64>,
+
+	/// Whether the vehicle has a laser rangefinder.
+	pub has_laser: bool,
+
+	/// Projectiles from all weapon modules.
+	pub projectiles: Vec<Projectile>,
+}
+
+/// A single projectile (bullet, shell, or rocket/missile).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Projectile {
+	/// Projectile name (e.g. "30mm_UBR6").
+	pub name: String,
+
+	/// Projectile type (e.g. "ap_t", "he_frag_i", "apds_fs_long_tank").
+	pub bullet_type: String,
+
+	/// Mass in kg.
+	pub mass: Option<f64>,
+
+	/// Ballistic caliber in meters (e.g. 0.03 for 30mm).
+	pub ballistic_caliber: Option<f64>,
+
+	/// Muzzle velocity in m/s.
+	pub speed: Option<f64>,
+
+	/// Drag coefficient (averaged if source was an array).
+	pub cx: Option<f64>,
+
+	/// Explosive filler mass in kg.
+	pub explosive_mass: Option<f64>,
+
+	/// Explosive type (e.g. "a_ix_2", "ocfol").
+	pub explosive_type: Option<String>,
+
+	/// Damage mass for sub-caliber rounds.
+	pub damage_mass: Option<f64>,
+
+	/// Damage caliber for sub-caliber rounds.
+	pub damage_caliber: Option<f64>,
+
+	/// DeMarre penetration parameters.
+	pub demarre: Option<DemarreParams>,
+
+	/// Armor penetration for ATGMs/rockets (single value).
+	pub armor_power: Option<f64>,
+
+	/// Armor power series for APDS/APFSDS (distance -> penetration).
+	pub armor_power_series: Option<ArmorPowerSeries>,
+}
+
+/// DeMarre penetration formula parameters.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DemarreParams {
+	pub k: f64,
+	pub speed_pow: f64,
+	pub mass_pow: f64,
+	pub caliber_pow: f64,
+}
+
+/// Distance-indexed armor power values for APDS/APFSDS rounds.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ArmorPowerSeries {
+	pub ap_0m: Option<f64>,
+	pub ap_100m: Option<f64>,
+	pub ap_500m: Option<f64>,
+	pub ap_1000m: Option<f64>,
+	pub ap_1500m: Option<f64>,
+	pub ap_2000m: Option<f64>,
+	pub ap_2500m: Option<f64>,
+	pub ap_3000m: Option<f64>,
+	pub ap_3500m: Option<f64>,
+	pub ap_4000m: Option<f64>,
+	pub ap_4500m: Option<f64>,
+	pub ap_10000m: Option<f64>,
+}
+
+impl VehicleData {
+	/// Create a new empty vehicle data struct.
+	#[must_use]
+	pub fn new(id: impl Into<String>) -> Self {
+		Self {
+			id: id.into(),
+			weapon_path: None,
+			rocket_paths: Vec::new(),
+			zoom_in: None,
+			zoom_out: None,
+			zoom_in_2: None,
+			zoom_out_2: None,
+			has_laser: false,
+			projectiles: Vec::new(),
+		}
+	}
+
+	/// Whether the vehicle has any weapon data worth emitting.
+	///
+	/// Returns `false` for unarmed/non-playable vehicles (e.g. fire control trucks
+	/// in multi-part SAM systems) that only have zoom/laser data but no projectiles.
+	#[must_use]
+	pub fn is_armed(&self) -> bool {
+		!self.projectiles.is_empty()
+	}
+}

--- a/tools/fcsgen/core/src/parser/mod.rs
+++ b/tools/fcsgen/core/src/parser/mod.rs
@@ -1,0 +1,7 @@
+//! Parser for War Thunder datamine files.
+
+pub mod vehicle;
+pub mod weapon;
+
+pub use vehicle::parse_vehicle;
+pub use weapon::parse_weapon_module;

--- a/tools/fcsgen/core/src/parser/vehicle.rs
+++ b/tools/fcsgen/core/src/parser/vehicle.rs
@@ -1,0 +1,222 @@
+//! Parser for vehicle .blkx files.
+//!
+//! Extracts header information: weapon paths, rocket paths, zoom values, and laser presence.
+
+use serde_json::Value;
+
+use crate::error::Result;
+use crate::model::VehicleData;
+
+/// Parsed weapon entry from a vehicle file.
+#[derive(Debug, Clone)]
+pub struct WeaponEntry {
+	pub blk_path: String,
+	pub trigger: Option<String>,
+	pub trigger_group: Option<String>,
+}
+
+/// Parse a vehicle .blkx file and extract header information.
+///
+/// # Arguments
+/// * `json` - The parsed JSON content of the vehicle file
+/// * `vehicle_id` - The vehicle identifier (basename without extension)
+///
+/// # Returns
+/// A `VehicleData` struct with header fields populated (but no projectiles yet).
+pub fn parse_vehicle(json: &Value, vehicle_id: &str) -> Result<VehicleData> {
+	let mut data = VehicleData::new(vehicle_id);
+
+	// Extract zoom values from cockpit
+	if let Some(cockpit) = json.get("cockpit") {
+		extract_zoom_values(cockpit, &mut data);
+	}
+
+	// Check for laser rangefinder (broad heuristic matching legacy behavior)
+	data.has_laser = check_has_laser(json);
+
+	// Extract weapon paths from top-level commonWeapons
+	if let Some(common_weapons) = json.get("commonWeapons") {
+		let weapons = extract_weapon_entries(common_weapons);
+		classify_weapons(&weapons, &mut data);
+	}
+
+	// Also scan modifications for effects.commonWeapons blocks
+	// These contain weapons unlocked by modifications (e.g., upgraded ATGMs, different guns)
+	if let Some(Value::Object(modifications)) = json.get("modifications") {
+		for (_mod_name, mod_value) in modifications {
+			if let Some(common_weapons) = mod_value
+				.get("effects")
+				.and_then(|e| e.get("commonWeapons"))
+			{
+				let weapons = extract_weapon_entries(common_weapons);
+				classify_weapons(&weapons, &mut data);
+			}
+		}
+	}
+
+	Ok(data)
+}
+
+/// Extract zoom values from the cockpit object.
+fn extract_zoom_values(cockpit: &Value, data: &mut VehicleData) {
+	// Handle both single cockpit object and array of cockpits
+	match cockpit {
+		Value::Object(obj) => {
+			data.zoom_in = extract_fov_value(obj.get("zoomInFov"));
+			data.zoom_out = extract_fov_value(obj.get("zoomOutFov"));
+		},
+		Value::Array(arr) => {
+			// First cockpit is primary
+			if let Some(Value::Object(obj)) = arr.first() {
+				data.zoom_in = extract_fov_value(obj.get("zoomInFov"));
+				data.zoom_out = extract_fov_value(obj.get("zoomOutFov"));
+			}
+			// Second cockpit is secondary optics
+			if let Some(Value::Object(obj)) = arr.get(1) {
+				data.zoom_in_2 = extract_fov_value(obj.get("zoomInFov"));
+				data.zoom_out_2 = extract_fov_value(obj.get("zoomOutFov"));
+			}
+		},
+		_ => {},
+	}
+}
+
+/// Extract FOV value, handling both scalar and array cases.
+fn extract_fov_value(value: Option<&Value>) -> Option<f64> {
+	match value {
+		Some(Value::Number(n)) => n.as_f64(),
+		Some(Value::Array(arr)) => {
+			// Take first numeric value from array
+			arr.iter().find_map(|v| v.as_f64())
+		},
+		_ => None,
+	}
+}
+
+/// Check if the vehicle has a laser rangefinder.
+/// Uses broad substring matching to match legacy behavior.
+/// Note: Legacy uses case-sensitive matching, so "LaserBeamRidingSensor" does NOT match.
+///
+/// TODO: This is a very crude heuristic that also matches laser warning systems (LWS),
+/// thermal imaging systems with "laser" in their names, etc. In practice this usually
+/// works because vehicles with LWS typically also have a laser rangefinder, but ideally
+/// we should look for specific fields like "modern_tank_laser_rangefinder" modification
+/// or the "isLaser" field in the modifications section to properly detect this.
+fn check_has_laser(json: &Value) -> bool {
+	// Case-sensitive search for "laser" substring
+	// Legacy C# uses String.Contains which is case-sensitive by default
+	// This means "LaserBeamRidingSensor" (missile guidance) doesn't trigger it,
+	// but "modern_tank_laser_rangefinder" or "isLaser" does.
+	let json_str = json.to_string();
+	json_str.contains("laser")
+}
+
+/// Extract weapon entries from commonWeapons.
+fn extract_weapon_entries(common_weapons: &Value) -> Vec<WeaponEntry> {
+	let mut entries = Vec::new();
+
+	let weapons = match common_weapons.get("Weapon") {
+		Some(Value::Array(arr)) => arr.as_slice(),
+		Some(obj @ Value::Object(_)) => std::slice::from_ref(obj),
+		_ => return entries,
+	};
+
+	for weapon in weapons {
+		if let Some(blk) = weapon.get("blk").and_then(Value::as_str) {
+			entries.push(WeaponEntry {
+				blk_path: normalize_blk_path(blk),
+				trigger: weapon
+					.get("trigger")
+					.and_then(Value::as_str)
+					.map(String::from),
+				trigger_group: weapon
+					.get("triggerGroup")
+					.and_then(Value::as_str)
+					.map(String::from),
+			});
+		}
+	}
+
+	entries
+}
+
+/// Normalize .blk path to .blkx (legacy behavior: append 'x').
+fn normalize_blk_path(path: &str) -> String {
+	if path.ends_with(".blk") {
+		format!("{path}x")
+	} else {
+		path.to_string()
+	}
+}
+
+/// Classify weapons into primary weapon and rocket paths.
+///
+/// Legacy behavior:
+/// - First weapon with "groundModels_weapons" in path becomes weapon_path
+/// - Weapons with triggerGroup "special" become rocket_paths (up to 2 unique)
+fn classify_weapons(weapons: &[WeaponEntry], data: &mut VehicleData) {
+	// Find primary weapon (first one with groundModels_weapons that isn't special)
+	for weapon in weapons {
+		if weapon.blk_path.contains("groundModels_weapons")
+			&& weapon.trigger_group.as_deref() != Some("special")
+			&& data.weapon_path.is_none()
+		{
+			data.weapon_path = Some(weapon.blk_path.clone());
+			break;
+		}
+	}
+
+	// Find rocket paths (triggerGroup == "special")
+	for weapon in weapons {
+		if weapon.trigger_group.as_deref() == Some("special") {
+			if !data.rocket_paths.contains(&weapon.blk_path) && data.rocket_paths.len() < 2 {
+				data.rocket_paths.push(weapon.blk_path.clone());
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use serde_json::json;
+
+	#[test]
+	fn test_extract_zoom_scalar() {
+		let cockpit = json!({
+			"zoomInFov": 6.14,
+			"zoomOutFov": 29.8
+		});
+		let mut data = VehicleData::new("test");
+		extract_zoom_values(&cockpit, &mut data);
+
+		assert!((data.zoom_in.unwrap() - 6.14).abs() < 0.001);
+		assert!((data.zoom_out.unwrap() - 29.8).abs() < 0.001);
+	}
+
+	#[test]
+	fn test_extract_zoom_array() {
+		let cockpit = json!({
+			"zoomInFov": [6.0, 8.0, 10.0],
+			"zoomOutFov": [30.0, 40.0]
+		});
+		let mut data = VehicleData::new("test");
+		extract_zoom_values(&cockpit, &mut data);
+
+		// Should take first value from arrays
+		assert!((data.zoom_in.unwrap() - 6.0).abs() < 0.001);
+		assert!((data.zoom_out.unwrap() - 30.0).abs() < 0.001);
+	}
+
+	#[test]
+	fn test_normalize_blk_path() {
+		assert_eq!(
+			normalize_blk_path("gameData/Weapons/test.blk"),
+			"gameData/Weapons/test.blkx"
+		);
+		assert_eq!(
+			normalize_blk_path("gameData/Weapons/test.blkx"),
+			"gameData/Weapons/test.blkx"
+		);
+	}
+}

--- a/tools/fcsgen/core/src/parser/weapon.rs
+++ b/tools/fcsgen/core/src/parser/weapon.rs
@@ -1,0 +1,562 @@
+//! Parser for weapon module .blkx files.
+//!
+//! Extracts projectile data: mass, caliber, speed, Cx, explosive, DeMarre params, etc.
+//!
+//! # Legacy Behavior
+//!
+//! The legacy tool processes weapon files line-by-line with bracket counting that
+//! depends on indentation. Due to a quirk in the legacy code:
+//!
+//! - **Top-level bullets** (2-space indent): Bracket increments for `{`, so the loop
+//!   reads through ALL array elements and merges with last-wins semantics.
+//!
+//! - **Belt bullets** (4-space indent): Bracket doesn't increment for first `{` because
+//!   the check for `"    \"bullet\":"` matches, so only the FIRST bullet is read.
+//!
+//! This explains why the top-level bullet array [UBR6, UOF8] outputs UOF8 (last-wins),
+//! while belt arrays like AP [UBR6, UBR6, UBR6, UOR6] output UBR6 (first only).
+//!
+//! Belt sections (like "30mm_2a42_HE") are filtered based on whether that belt
+//! name exists in the vehicle data. Top-level bullets are always included.
+
+use serde_json::Value;
+
+use crate::error::Result;
+use crate::model::{ArmorPowerSeries, DemarreParams, Projectile};
+
+/// Parse a weapon module .blkx file and extract projectile data.
+///
+/// # Arguments
+/// * `json` - The parsed JSON content of the weapon module file
+/// * `vehicle_json` - Optional vehicle JSON for belt filtering. If `None`, all belts included.
+///
+/// # Returns
+/// A vector of `Projectile` structs extracted from the module.
+pub fn parse_weapon_module(json: &Value, vehicle_json: Option<&Value>) -> Result<Vec<Projectile>> {
+	let mut projectiles = Vec::new();
+
+	// Convert vehicle JSON to string for belt membership checks (matches legacy behavior)
+	let vehicle_str = vehicle_json.map(|v| v.to_string());
+
+	// Process the JSON object in insertion order (serde_json preserves order)
+	if let Value::Object(obj) = json {
+		for (key, value) in obj {
+			match key.as_str() {
+				"bullet" => {
+					// Top-level bullet - merge all array elements (last-wins)
+					if let Some(proj) = collect_bullet_merged(value) {
+						projectiles.push(proj);
+					}
+				},
+				"rocket" => {
+					// Top-level rocket - merge all array elements (last-wins)
+					if let Some(proj) = collect_bullet_merged(value) {
+						projectiles.push(proj);
+					}
+				},
+				_ => {
+					// Could be a belt section - check if it should be included
+					// Belts with rocket/ATGM data are always included (they're not
+					// modification-gated); regular ammo belts are filtered by vehicle data.
+					let include = belt_has_rocket(value)
+						|| (value.is_object()
+							&& should_include_belt(key, vehicle_str.as_deref()));
+					if include {
+						// Look for bullet/rocket within this belt section
+						if let Value::Object(belt) = value {
+							if let Some(bullets) = belt.get("bullet") {
+								// Belt bullets - only first element (legacy bracket behavior)
+								if let Some(proj) = collect_bullet_first(bullets) {
+									projectiles.push(proj);
+								}
+							}
+							if let Some(rockets) = belt.get("rocket") {
+								// Belt rockets - only first element
+								if let Some(proj) = collect_bullet_first(rockets) {
+									projectiles.push(proj);
+								}
+							}
+						}
+					}
+				},
+			}
+		}
+	}
+
+	Ok(projectiles)
+}
+
+/// Collect ONE bullet from an array, merging ALL elements with last-wins semantics.
+/// Used for top-level bullets where legacy bracket counting reads the entire array.
+fn collect_bullet_merged(value: &Value) -> Option<Projectile> {
+	match value {
+		Value::Array(arr) => {
+			// Merge all array entries, last wins
+			let mut merged = MergedBullet::default();
+			for bullet in arr {
+				merged.merge(bullet);
+			}
+			merged.to_projectile()
+		},
+		Value::Object(_) => {
+			let mut merged = MergedBullet::default();
+			merged.merge(value);
+			merged.to_projectile()
+		},
+		_ => None,
+	}
+}
+
+/// Collect ONE bullet from an array, using ONLY the first element.
+/// Used for belt bullets where legacy bracket counting exits after first bullet.
+fn collect_bullet_first(value: &Value) -> Option<Projectile> {
+	match value {
+		Value::Array(arr) => {
+			// Take ONLY the first element (legacy behavior for belts)
+			if let Some(first) = arr.first() {
+				let mut merged = MergedBullet::default();
+				merged.merge(first);
+				merged.to_projectile()
+			} else {
+				None
+			}
+		},
+		Value::Object(_) => {
+			let mut merged = MergedBullet::default();
+			merged.merge(value);
+			merged.to_projectile()
+		},
+		_ => None,
+	}
+}
+
+/// Helper struct for merging bullet values with last-wins semantics.
+#[derive(Default)]
+struct MergedBullet {
+	bullet_name: Option<String>,
+	bullet_type: Option<String>,
+	mass: Option<f64>,
+	caliber: Option<f64>,
+	speed: Option<f64>,
+	cx: Option<f64>,
+	explosive_mass: Option<f64>,
+	explosive_type: Option<String>,
+	damage_mass: Option<f64>,
+	damage_caliber: Option<f64>,
+	demarre_k: Option<f64>,
+	demarre_speed_pow: Option<f64>,
+	demarre_mass_pow: Option<f64>,
+	demarre_caliber_pow: Option<f64>,
+	armor_power: Option<f64>,
+	armorpower_json: Option<Value>, // Store raw armorpower section for APDS extraction
+}
+
+impl MergedBullet {
+	/// Merge values from a bullet object, overwriting any existing values.
+	fn merge(&mut self, bullet: &Value) {
+		// For rockets/ATGMs, data may be nested under "rocket"
+		let rocket = bullet.get("rocket");
+		let data_source = rocket.unwrap_or(bullet);
+
+		// Extract bullet name (can be string or array)
+		if let Some(name) = extract_bullet_name(bullet) {
+			self.bullet_name = Some(name);
+		}
+
+		if let Some(bt) = bullet.get("bulletType").and_then(Value::as_str) {
+			self.bullet_type = Some(bt.to_string());
+		}
+		// Legacy scans line-by-line with last-wins, so rocket.bulletType overwrites outer
+		if let Some(bt) = bullet
+			.get("rocket")
+			.and_then(|r| r.get("bulletType"))
+			.and_then(Value::as_str)
+		{
+			self.bullet_type = Some(bt.to_string());
+		}
+
+		// Mass - try rocket section first, then bullet level
+		if let Some(v) = data_source.get("mass").and_then(Value::as_f64) {
+			self.mass = Some(v);
+		} else if let Some(v) = bullet.get("mass").and_then(Value::as_f64) {
+			self.mass = Some(v);
+		}
+
+		// Caliber - prefer ballisticCaliber, then caliber
+		if let Some(v) = data_source.get("ballisticCaliber").and_then(Value::as_f64) {
+			self.caliber = Some(v);
+		} else if let Some(v) = data_source.get("caliber").and_then(Value::as_f64) {
+			self.caliber = Some(v);
+		} else if let Some(v) = bullet.get("caliber").and_then(Value::as_f64) {
+			self.caliber = Some(v);
+		}
+
+		// Speed - prefer endSpeed, then speed
+		if let Some(v) = data_source.get("endSpeed").and_then(Value::as_f64) {
+			self.speed = Some(v);
+		} else if let Some(v) = data_source.get("speed").and_then(Value::as_f64) {
+			self.speed = Some(v);
+		}
+
+		// Cx
+		if let Some(cx) = extract_cx(data_source) {
+			self.cx = Some(cx);
+		}
+
+		// Explosive
+		if let Some(v) = data_source.get("explosiveMass").and_then(Value::as_f64) {
+			self.explosive_mass = Some(v);
+		}
+		if let Some(v) = data_source.get("explosiveType").and_then(Value::as_str) {
+			self.explosive_type = Some(v.to_string());
+		}
+
+		// Damage
+		if let Some(v) = data_source.get("damageMass").and_then(Value::as_f64) {
+			self.damage_mass = Some(v);
+		}
+		if let Some(v) = extract_f64_or_first(data_source, "damageCaliber") {
+			self.damage_caliber = Some(v);
+		} else if let Some(v) = extract_f64_or_first(bullet, "damageCaliber") {
+			self.damage_caliber = Some(v);
+		}
+
+		// DeMarre - check bullet level, damage.kinetic, and rocket.damage.kinetic
+		self.merge_demarre(bullet);
+
+		// Armor power
+		if let Some(v) = extract_armor_power(bullet) {
+			self.armor_power = Some(v);
+		}
+
+		// Store armorpower section for APDS series extraction
+		if let Some(ap) = bullet.get("armorpower") {
+			self.armorpower_json = Some(ap.clone());
+		}
+	}
+
+	fn merge_demarre(&mut self, bullet: &Value) {
+		let rocket_damage_kinetic = bullet
+			.get("rocket")
+			.and_then(|r| r.get("damage"))
+			.and_then(|d| d.get("kinetic"));
+		let bullet_damage_kinetic = bullet
+			.get("damage")
+			.and_then(|d| d.get("kinetic"));
+
+		let sources = [
+			Some(bullet),
+			bullet_damage_kinetic,
+			rocket_damage_kinetic,
+		];
+
+		for source in sources.into_iter().flatten() {
+			if let Some(v) = source.get("demarrePenetrationK").and_then(Value::as_f64) {
+				self.demarre_k = Some(v);
+			}
+			if let Some(v) = source.get("demarreSpeedPow").and_then(Value::as_f64) {
+				self.demarre_speed_pow = Some(v);
+			}
+			if let Some(v) = source.get("demarreMassPow").and_then(Value::as_f64) {
+				self.demarre_mass_pow = Some(v);
+			}
+			if let Some(v) = source.get("demarreCaliberPow").and_then(Value::as_f64) {
+				self.demarre_caliber_pow = Some(v);
+			}
+		}
+	}
+
+	fn to_projectile(self) -> Option<Projectile> {
+		// Name and type are required
+		let name = self.bullet_name?;
+		let bullet_type = self.bullet_type?;
+
+		let demarre = if self.demarre_k.is_some()
+			|| self.demarre_speed_pow.is_some()
+			|| self.demarre_mass_pow.is_some()
+			|| self.demarre_caliber_pow.is_some()
+		{
+			Some(DemarreParams {
+				k: self.demarre_k.unwrap_or(0.9),
+				speed_pow: self.demarre_speed_pow.unwrap_or(1.43),
+				mass_pow: self.demarre_mass_pow.unwrap_or(0.71),
+				caliber_pow: self.demarre_caliber_pow.unwrap_or(1.07),
+			})
+		} else {
+			None
+		};
+
+		// Armor power series for APDS/APFSDS
+		let armor_power_series = if bullet_type.starts_with("apds") {
+			self.armorpower_json
+				.as_ref()
+				.map(extract_armor_power_series)
+		} else {
+			None
+		};
+
+		Some(Projectile {
+			name,
+			bullet_type,
+			mass: self.mass,
+			ballistic_caliber: self.caliber,
+			speed: self.speed,
+			cx: self.cx,
+			explosive_mass: self.explosive_mass,
+			explosive_type: self.explosive_type,
+			damage_mass: self.damage_mass,
+			damage_caliber: self.damage_caliber,
+			demarre,
+			armor_power: self.armor_power,
+			armor_power_series,
+		})
+	}
+}
+
+/// Check if a belt section contains rocket/ATGM data (nested `rocket` inside `bullet`).
+/// Such belts represent gun-launched ATGMs or missiles and should always be included
+/// regardless of belt filtering, since they're not modification-gated ammo belts.
+fn belt_has_rocket(value: &Value) -> bool {
+	if let Value::Object(belt) = value {
+		// Check bullet sub-objects for a nested "rocket" section
+		if let Some(bullets) = belt.get("bullet") {
+			let bullet_iter: Box<dyn Iterator<Item = &Value>> = match bullets {
+				Value::Array(arr) => Box::new(arr.iter()),
+				obj @ Value::Object(_) => Box::new(std::iter::once(obj)),
+				_ => return false,
+			};
+			for bullet in bullet_iter {
+				if bullet.get("rocket").is_some() {
+					return true;
+				}
+			}
+		}
+		// Check for direct "rocket" key in belt (standalone rocket sections)
+		if let Some(rockets) = belt.get("rocket") {
+			match rockets {
+				Value::Object(_) | Value::Array(_) => return true,
+				_ => {}
+			}
+		}
+	}
+	false
+}
+
+/// Check if a belt should be included based on vehicle data.
+fn should_include_belt(belt_name: &str, vehicle_str: Option<&str>) -> bool {
+	let vehicle_str = match vehicle_str {
+		Some(s) => s,
+		None => return true, // No vehicle data, include all
+	};
+
+	// Direct check
+	if vehicle_str.contains(belt_name) {
+		return true;
+	}
+
+	// Try with nation prefixes stripped (legacy behavior)
+	let normalized = strip_nation_prefix(belt_name);
+	if normalized != belt_name && vehicle_str.contains(&normalized) {
+		return true;
+	}
+
+	false
+}
+
+/// Strip nation prefix from belt name (legacy behavior).
+fn strip_nation_prefix(name: &str) -> String {
+	let prefixes = [
+		"_cn_", "_fr_", "_germ_", "_il_", "_it_", "_jp_", "_sw_", "_uk_", "_us_", "_ussr_",
+	];
+
+	let mut result = name.to_string();
+	for prefix in prefixes {
+		result = result.replace(prefix, "_");
+	}
+	result
+}
+
+/// Extract bullet name, handling both scalar and array cases.
+/// When no bulletName exists, fallback to bulletType + "/name/short" (legacy behavior).
+fn extract_bullet_name(bullet: &Value) -> Option<String> {
+	match bullet.get("bulletName") {
+		Some(Value::String(s)) => Some(s.clone()),
+		Some(Value::Array(arr)) => arr.first().and_then(Value::as_str).map(String::from),
+		_ => {
+			// Fallback: bulletType + "/name/short" (legacy behavior)
+			bullet
+				.get("bulletType")
+				.and_then(Value::as_str)
+				.map(|s| format!("{s}/name/short"))
+		},
+	}
+}
+
+/// Extract Cx drag coefficient, handling both scalar and array cases.
+/// For arrays, legacy tool averages all values and rounds to 4 decimal places.
+fn extract_cx(obj: &Value) -> Option<f64> {
+	match obj.get("Cx") {
+		Some(Value::Number(n)) => n.as_f64(),
+		Some(Value::Array(arr)) => {
+			// Legacy behavior: average all array values, round to 4 decimal places
+			let values: Vec<f64> = arr.iter().filter_map(Value::as_f64).collect();
+			if values.is_empty() {
+				None
+			} else {
+				let avg = values.iter().sum::<f64>() / values.len() as f64;
+				// Math.Round(average, 4) in C#
+				Some((avg * 10000.0).round() / 10000.0)
+			}
+		},
+		_ => None,
+	}
+}
+
+/// Extract a float value from a key, handling both scalar and array cases.
+/// For arrays, takes the first element (matching legacy line-scan behavior).
+fn extract_f64_or_first(obj: &Value, key: &str) -> Option<f64> {
+	match obj.get(key) {
+		Some(Value::Number(n)) => n.as_f64(),
+		Some(Value::Array(arr)) => arr.first().and_then(Value::as_f64),
+		_ => None,
+	}
+}
+
+/// Extract armor power for ATGMs/rockets.
+fn extract_armor_power(bullet: &Value) -> Option<f64> {
+	// Check multiple possible locations
+	let sources = [
+		bullet.get("cumulativeDamage"),
+		bullet.get("rocket").and_then(|r| r.get("cumulativeDamage")),
+		Some(bullet),
+	];
+
+	for source in sources.into_iter().flatten() {
+		if let Some(v) = source.get("armorPower").and_then(Value::as_f64) {
+			return Some(v);
+		}
+	}
+
+	None
+}
+
+/// Extract armor power series from armorpower JSON object.
+/// The armorpower section has keys like "ArmorPower0m", "ArmorPower100m", etc.
+/// Values are arrays [penetration, distance], we only need the penetration (first element).
+fn extract_armor_power_series(armorpower: &Value) -> ArmorPowerSeries {
+	/// Extract penetration value from ArmorPowerXXXm array.
+	fn get_ap(obj: &Value, key: &str) -> Option<f64> {
+		obj.get(key).and_then(|v| match v {
+			Value::Array(arr) => arr.first().and_then(Value::as_f64),
+			Value::Number(n) => n.as_f64(),
+			_ => None,
+		})
+	}
+
+	ArmorPowerSeries {
+		ap_0m: get_ap(armorpower, "ArmorPower0m"),
+		ap_100m: get_ap(armorpower, "ArmorPower100m"),
+		ap_500m: get_ap(armorpower, "ArmorPower500m"),
+		ap_1000m: get_ap(armorpower, "ArmorPower1000m"),
+		ap_1500m: get_ap(armorpower, "ArmorPower1500m"),
+		ap_2000m: get_ap(armorpower, "ArmorPower2000m"),
+		ap_2500m: get_ap(armorpower, "ArmorPower2500m"),
+		ap_3000m: get_ap(armorpower, "ArmorPower3000m"),
+		ap_3500m: get_ap(armorpower, "ArmorPower3500m"),
+		ap_4000m: get_ap(armorpower, "ArmorPower4000m"),
+		ap_4500m: get_ap(armorpower, "ArmorPower4500m"),
+		ap_10000m: get_ap(armorpower, "ArmorPower10000m"),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use serde_json::json;
+
+	#[test]
+	fn test_extract_cx_array() {
+		let obj = json!({ "Cx": [0.3, 0.4, 0.5] });
+		let cx = extract_cx(&obj);
+		// Should average all values: (0.3 + 0.4 + 0.5) / 3 = 0.4, rounded to 4 decimal places
+		assert!((cx.unwrap() - 0.4).abs() < 0.00001);
+
+		// Test rounding to 4 decimal places
+		let obj2 = json!({ "Cx": [0.276611, 0.33] });
+		let cx2 = extract_cx(&obj2);
+		// Average = 0.303305... rounds to 0.3033
+		assert!((cx2.unwrap() - 0.3033).abs() < 0.00001);
+	}
+
+	#[test]
+	fn test_extract_bullet_name_array() {
+		let bullet = json!({
+			"bulletName": ["first_name", "second_name"],
+			"bulletType": "ap_t"
+		});
+		let name = extract_bullet_name(&bullet);
+		assert_eq!(name, Some("first_name".to_string()));
+	}
+
+	#[test]
+	fn test_belt_filtering() {
+		let weapon = json!({
+			"bullet": [{
+				"bulletName": "top_level",
+				"bulletType": "ap"
+			}],
+			"30mm_HE": {
+				"bullet": [{
+					"bulletName": "belt_bullet",
+					"bulletType": "he"
+				}]
+			}
+		});
+
+		// No vehicle filter - should include both
+		let result = parse_weapon_module(&weapon, None).unwrap();
+		assert_eq!(result.len(), 2);
+
+		// With vehicle filter that includes 30mm_HE
+		let vehicle = json!({"30mm_HE": {}});
+		let result = parse_weapon_module(&weapon, Some(&vehicle)).unwrap();
+		assert_eq!(result.len(), 2);
+
+		// With vehicle filter that excludes 30mm_HE
+		let vehicle = json!({"other_belt": {}});
+		let result = parse_weapon_module(&weapon, Some(&vehicle)).unwrap();
+		assert_eq!(result.len(), 1);
+		assert_eq!(result[0].name, "top_level");
+	}
+
+	#[test]
+	fn test_belt_with_rocket_always_included() {
+		let weapon = json!({
+			"bullet": [{
+				"bulletName": "top_level",
+				"bulletType": "ap"
+			}],
+			"125mm_china_ATGM": {
+				"bullet": {
+					"bulletType": "atgm_tandem_tank",
+					"mass": 19.0,
+					"caliber": 0.125,
+					"speed": 470.0,
+					"rocket": {
+						"mass": 19.0,
+						"caliber": 0.125,
+						"endSpeed": 470.0,
+						"explosiveMass": 3.6,
+						"explosiveType": "ocfol"
+					}
+				}
+			}
+		});
+
+		// Even with a vehicle that has NO matching belt, the ATGM belt should be included
+		let vehicle = json!({"125mm_china_HE": {}});
+		let result = parse_weapon_module(&weapon, Some(&vehicle)).unwrap();
+		assert_eq!(result.len(), 2, "ATGM belt should be included: {:?}", result);
+		assert_eq!(result[1].bullet_type, "atgm_tandem_tank");
+	}
+}

--- a/tools/fcsgen/core/tests/stage1.rs
+++ b/tools/fcsgen/core/tests/stage1.rs
@@ -1,0 +1,309 @@
+//! Integration tests for Stage 1 conversion.
+//!
+//! Uses block-level comparison: parses the legacy .txt format into a header
+//! and a set of ammo blocks, then checks that each unique expected ammo block
+//! has at least one exact match in our output. This tolerates block reordering
+//! and duplicate blocks.
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+
+use fcsgen_core::{convert_vehicle, emit_legacy_txt};
+
+/// Parsed representation of a legacy .txt output file.
+#[allow(dead_code)]
+struct ParsedOutput {
+	weapon_path: Option<String>,
+	rocket_paths: Vec<String>,
+	zoom_in: Option<String>,
+	zoom_out: Option<String>,
+	has_laser: bool,
+	ammo_blocks: Vec<HashMap<String, String>>,
+}
+
+/// Parse a legacy .txt file into structured header + ammo blocks.
+fn parse_legacy_txt(text: &str) -> ParsedOutput {
+	let text = text.replace("\r\n", "\n");
+	let sections: Vec<&str> = text.split("\n\n").collect();
+
+	let mut weapon_path = None;
+	let mut rocket_paths = Vec::new();
+	let mut zoom_in = None;
+	let mut zoom_out = None;
+	let mut has_laser = false;
+
+	// First section is header
+	if let Some(header) = sections.first() {
+		for line in header.lines() {
+			let line = line.trim();
+			if let Some((key, value)) = line.split_once(':') {
+				match key {
+					"WeaponPath" => weapon_path = Some(value.to_string()),
+					"RocketPath" => rocket_paths.push(value.to_string()),
+					"ZoomIn" => zoom_in = Some(value.to_string()),
+					"ZoomOut" => zoom_out = Some(value.to_string()),
+					_ => {}
+				}
+			} else if line == "HasLaser" {
+				has_laser = true;
+			}
+		}
+	}
+
+	// Remaining sections are ammo blocks
+	let mut ammo_blocks = Vec::new();
+	for section in sections.iter().skip(1) {
+		let mut block = HashMap::new();
+		for line in section.lines() {
+			let line = line.trim();
+			if line.is_empty() {
+				continue;
+			}
+			if let Some((key, value)) = line.split_once(':') {
+				block.insert(key.to_string(), value.to_string());
+			}
+		}
+		if !block.is_empty() {
+			ammo_blocks.push(block);
+		}
+	}
+
+	ParsedOutput { weapon_path, rocket_paths, zoom_in, zoom_out, has_laser, ammo_blocks }
+}
+
+/// Convert an ammo block to a canonical string for deduplication and lookup.
+fn block_to_canonical(block: &HashMap<String, String>) -> String {
+	let mut pairs: Vec<_> = block.iter().collect();
+	pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+	pairs.iter().map(|(k, v)| format!("{k}:{v}")).collect::<Vec<_>>().join("\n")
+}
+
+/// Get the path to the test_data directory.
+fn test_data_dir() -> PathBuf {
+	PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+		.parent()
+		.unwrap()
+		.join("test_data")
+}
+
+/// Convert a single vehicle and do block-level comparison to expected output.
+///
+/// Header fields (ZoomIn, ZoomOut, HasLaser) must match exactly.
+/// Each unique expected ammo block must have at least one exact match in our output.
+/// Block ordering and duplicate blocks are ignored.
+fn check_vehicle(vehicle_name: &str) -> Result<(), String> {
+	let vehicle_path = test_data_dir()
+		.join("datamine")
+		.join("aces.vromfs.bin_u")
+		.join("gamedata")
+		.join("units")
+		.join("tankmodels")
+		.join(format!("{vehicle_name}.blkx"));
+
+	let expected_data_dir = test_data_dir().join("expected").join("data");
+	let expected_path = expected_data_dir.join(format!("{vehicle_name}.txt"));
+
+	// Convert
+	let data = convert_vehicle(&vehicle_path, &test_data_dir().join("datamine"))
+		.map_err(|e| format!("conversion error: {e}"))?;
+	let output = emit_legacy_txt(&data);
+
+	// Load expected
+	let expected = std::fs::read_to_string(&expected_path)
+		.map_err(|e| format!("cannot read expected: {e}"))?;
+
+	let exp = parse_legacy_txt(&expected);
+	let out = parse_legacy_txt(&output);
+
+	let mut diffs = Vec::new();
+
+	// Header comparison (ZoomIn, ZoomOut, HasLaser matter for downstream;
+	// WeaponPath/RocketPath are not used downstream but flag them as info)
+	if exp.zoom_in != out.zoom_in {
+		diffs.push(format!("ZoomIn: expected {:?}, got {:?}", exp.zoom_in, out.zoom_in));
+	}
+	if exp.zoom_out != out.zoom_out {
+		diffs.push(format!("ZoomOut: expected {:?}, got {:?}", exp.zoom_out, out.zoom_out));
+	}
+	if exp.has_laser != out.has_laser {
+		diffs.push(format!("HasLaser: expected {}, got {}", exp.has_laser, out.has_laser));
+	}
+
+	// Ammo block comparison: each unique expected block must exist in our output
+	let output_canonicals: HashSet<String> =
+		out.ammo_blocks.iter().map(block_to_canonical).collect();
+
+	let mut seen_expected = HashSet::new();
+	for exp_block in &exp.ammo_blocks {
+		let canon = block_to_canonical(exp_block);
+		if !seen_expected.insert(canon.clone()) {
+			continue; // Skip duplicate expected blocks
+		}
+
+		if output_canonicals.contains(&canon) {
+			continue; // Exact match found
+		}
+
+		// No exact match — find closest block by Name for better diagnostics
+		let exp_name = exp_block.get("Name").map_or("???", |s| s.as_str());
+		let closest = out.ammo_blocks.iter().find(|b| {
+			b.get("Name").is_some_and(|n| n == exp_name)
+		});
+
+		if let Some(close) = closest {
+			let mut field_diffs = Vec::new();
+			for (k, v) in exp_block {
+				match close.get(k) {
+					Some(cv) if cv != v => {
+						field_diffs.push(format!("{k}: exp {v}, got {cv}"));
+					}
+					None => field_diffs.push(format!("{k}: exp {v}, got <missing>")),
+					_ => {}
+				}
+			}
+			for k in close.keys() {
+				if !exp_block.contains_key(k) {
+					field_diffs.push(format!("{k}: exp <missing>, got {}", close[k]));
+				}
+			}
+			diffs.push(format!("ammo '{exp_name}': {}", field_diffs.join(", ")));
+		} else {
+			// No block with this Name at all — truly missing
+			diffs.push(format!("ammo '{exp_name}': missing entirely"));
+		}
+	}
+
+	if diffs.is_empty() {
+		Ok(())
+	} else {
+		Err(diffs.join("; "))
+	}
+}
+
+/// Run conversion on ALL vehicles in the corpus and report statistics.
+#[test]
+fn test_full_corpus() {
+	let vehicles_path = test_data_dir()
+		.join("datamine")
+		.join("aces.vromfs.bin_u")
+		.join("gamedata")
+		.join("units")
+		.join("tankmodels");
+	let expected_data_dir = test_data_dir().join("expected").join("data");
+	let output_dir = test_data_dir().join("output");
+	if !vehicles_path.exists() {
+		eprintln!("Skipping corpus test: examples not present");
+		return;
+	}
+
+	// Ensure output directory exists
+	if !output_dir.exists() {
+		std::fs::create_dir_all(&output_dir).expect("create output dir");
+	}
+
+	// Collect all expected output files (these are the vehicles legacy tool produced output for)
+	let expected_files: Vec<_> = std::fs::read_dir(&expected_data_dir)
+		.expect("read output dir")
+		.filter_map(|e| e.ok())
+		.filter(|e| e.path().extension().is_some_and(|ext| ext == "txt"))
+		.map(|e| e.path().file_stem().unwrap().to_string_lossy().to_string())
+		.collect();
+
+	let total = expected_files.len();
+	let mut passed = 0;
+	let mut failed = 0;
+	let mut errors = 0;
+	let mut failures: Vec<(String, String)> = Vec::new();
+
+	// Write output for failing vehicles to output/data/ for inspection
+	let output_data_dir = output_dir.join("data");
+	if !output_data_dir.exists() {
+		std::fs::create_dir_all(&output_data_dir).expect("create output data dir");
+	}
+
+	for vehicle in &expected_files {
+		match check_vehicle(vehicle) {
+			Ok(()) => {
+				passed += 1;
+			},
+			Err(e) if e.starts_with("conversion error") => {
+				errors += 1;
+				if errors <= 10 {
+					eprintln!("ERROR {vehicle}: {e}");
+				}
+			},
+			Err(e) => {
+				failed += 1;
+				failures.push((vehicle.clone(), e));
+
+				// Write our output for this failing vehicle for inspection
+				let vehicle_path = vehicles_path.join(format!("{vehicle}.blkx"));
+				if let Ok(data) =
+					convert_vehicle(&vehicle_path, &test_data_dir().join("datamine"))
+				{
+					let output_text = emit_legacy_txt(&data);
+					let _ = std::fs::write(
+						output_data_dir.join(format!("{vehicle}.txt")),
+						&output_text,
+					);
+				}
+			},
+		}
+	}
+
+	// Print summary
+	eprintln!("\n{}", "=".repeat(60));
+	eprintln!("CORPUS TEST RESULTS");
+	eprintln!("{}", "=".repeat(60));
+	eprintln!("Total:  {total}");
+	eprintln!(
+		"Passed: {passed} ({:.1}%)",
+		100.0 * passed as f64 / total as f64
+	);
+	eprintln!(
+		"Failed: {failed} ({:.1}%)",
+		100.0 * failed as f64 / total as f64
+	);
+	eprintln!(
+		"Errors: {errors} ({:.1}%)",
+		100.0 * errors as f64 / total as f64
+	);
+
+	// Print first N failures with details to console
+	if !failures.is_empty() {
+		eprintln!("\nFirst 20 failures:");
+		for (vehicle, err) in failures.iter().take(20) {
+			eprintln!("  {vehicle}: {err}");
+		}
+
+		// Dump full failure list to file for reference
+		let failure_log = output_dir.join("corpus-failures.txt");
+		let mut report = String::new();
+		report.push_str(&format!("Corpus Test Failure Report\n"));
+		report.push_str(&format!("==========================\n\n"));
+		report.push_str(&format!("Total: {total}\n"));
+		report.push_str(&format!("Passed: {passed}\n"));
+		report.push_str(&format!("Failed: {failed}\n"));
+		report.push_str(&format!("Errors: {errors}\n\n"));
+		report.push_str(&format!("Failures ({failed} vehicles):\n"));
+		report.push_str(&format!("{}\n\n", "-".repeat(40)));
+
+		for (vehicle, err) in &failures {
+			report.push_str(&format!("{vehicle}\n  {err}\n\n"));
+		}
+
+		if let Err(e) = std::fs::write(&failure_log, &report) {
+			eprintln!("Warning: could not write failure log: {e}");
+		} else {
+			eprintln!("\nFull failure list written to: {}", failure_log.display());
+		}
+	}
+
+	// Fail if pass rate is below threshold (adjust as we improve)
+	let pass_rate = passed as f64 / total as f64;
+	assert!(
+		pass_rate >= 0.0, // Set to 0 for now, raise as we improve
+		"Pass rate {:.1}% below threshold",
+		pass_rate * 100.0
+	);
+}

--- a/tools/fcsgen/rustfmt.toml
+++ b/tools/fcsgen/rustfmt.toml
@@ -1,0 +1,12 @@
+hard_tabs = true # Not up to negotiation.
+brace_style = "PreferSameLine"
+enum_discrim_align_threshold = 20
+hex_literal_case = "Upper"
+imports_layout = "HorizontalVertical"
+match_block_trailing_comma = true
+imports_granularity = "Crate"
+newline_style = "Unix"
+normalize_comments = true
+reorder_impl_items = true
+group_imports = "StdExternalCrate"
+struct_field_align_threshold = 20


### PR DESCRIPTION
Introduce the Rust-based `fcsgen` Stage 1 pipeline, enabling conversion of datamine files to legacy Data format. This includes vehicle and weapon parsers, legacy emitters, and integration tests, along with a `convert` CLI subcommand for user interaction. Improved parsing fidelity for projectiles enhances overall functionality.