### PR TITLE
feat: add Stage 2 ballistic pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced the Rust-based `fcsgen` Stage 1 pipeline (`tools/fcsgen`) with vehicle and weapon parsers, legacy emitters, and integration tests plus a `convert` CLI subcommand for datamine-to-`Data/*.txt` conversion (#34).
 - Added a Stage 0 War Thunder datamine extraction step driven by the `wt_blk` crate, exposed via the `fcsgen extract` CLI subcommand and wired into the WinForms UI so users only need to point at their game install (#2).
 - Checked-in `tools/fcsgen/test_data/` corpus fixtures (datamine inputs + expected legacy outputs) so remote CI and contributors can run the Stage 1 integration suite without local War Thunder files.
+- Added the Stage 2 ballistic engine rewrite with corpus-level tests plus the new `fcsgen run` CLI that chains extract → convert → ballistic in one go (replacing the legacy C# computation).
+
 ### Fixed
 
 - Improved projectile parsing fidelity: APDS armor power series extraction, Cx array averaging, `/name/short` fallbacks, case-sensitive laser checks, and handling of modification `commonWeapons`, ATGM belts, rocket DeMarre values, and unarmed vehicles (stage 1 follow-ups for issue #19).
@@ -21,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added Rust formatting configuration so the new workspace adheres to repository style.
 - WinForms UI now shells out to `fcsgen run`, replacing the legacy inline datamine parser so Stage 1 lives entirely in Rust (closes the multi-button workflow gap).
+- Datamine processing now stays in-memory by default (with `--write-datamine` for debugging), eliminating ~150 MB of intermediates and simplifying the WinForms output layout.
 
 ### Removed
 

--- a/tools/fcsgen/cli/src/ballistic.rs
+++ b/tools/fcsgen/cli/src/ballistic.rs
@@ -1,0 +1,122 @@
+//! CLI orchestrator for the `ballistic` subcommand.
+//!
+//! Walks `Data/*.txt` files, parses each, runs the trajectory simulation
+//! for every projectile, and writes `Ballistic/{vehicle}/{shell}.txt`.
+
+use std::path::Path;
+
+use fcsgen_core::ballistic::{compute_ballistic, should_skip};
+use fcsgen_core::parser::data::parse_data_file;
+
+/// Run the ballistic computation pipeline.
+///
+/// # Arguments
+/// * `input`       – Directory containing `Data/*.txt` files (Stage 1 output).
+/// * `output`      – Directory to write `Ballistic/{vehicle}/{shell}.txt` into.
+/// * `sensitivity` – Mouse sensitivity value (0 < s ≤ 1, typically 0.50).
+/// * `filter`      – Optional list of vehicle IDs to process.
+pub fn run_ballistic(
+	input: &Path,
+	output: &Path,
+	sensitivity: f64,
+	filter: Option<&[String]>,
+) {
+	if !input.exists() {
+		eprintln!("Error: input directory not found at {input:?}");
+		std::process::exit(1);
+	}
+
+	if let Err(e) = std::fs::create_dir_all(output) {
+		eprintln!("Error: cannot create output directory: {e}");
+		std::process::exit(1);
+	}
+
+	// Collect *.txt files from input directory
+	let mut files: Vec<_> = std::fs::read_dir(input)
+		.expect("read input directory")
+		.filter_map(|e| e.ok())
+		.filter(|e| e.path().extension().is_some_and(|ext| ext == "txt"))
+		.filter(|e| {
+			if let Some(filter) = filter {
+				let stem = e.path().file_stem().unwrap().to_string_lossy().to_string();
+				filter.iter().any(|f| f == &stem)
+			} else {
+				true
+			}
+		})
+		.collect();
+
+	files.sort_by_key(std::fs::DirEntry::file_name);
+
+	let total = files.len();
+	let mut processed = 0;
+	let mut shells_written = 0;
+	let mut failed = 0;
+
+	eprintln!("Computing ballistic tables for {total} vehicles (sensitivity={sensitivity})");
+	eprintln!("Input:  {input:?}");
+	eprintln!("Output: {output:?}");
+	eprintln!();
+
+	for entry in &files {
+		let path = entry.path();
+		let vehicle_id = path
+			.file_stem()
+			.unwrap()
+			.to_str()
+			.unwrap_or("unknown");
+
+		let data = match parse_data_file(&path) {
+			Ok(d) => d,
+			Err(e) => {
+				eprintln!("PARSE ERROR {vehicle_id}: {e}");
+				failed += 1;
+				continue;
+			},
+		};
+
+		let vehicle_dir = output.join(vehicle_id);
+		let mut any_written = false;
+
+		for proj in &data.projectiles {
+			if should_skip(&proj.normalized_type) {
+				continue;
+			}
+
+			if let Some(content) = compute_ballistic(proj, sensitivity) {
+				if content.is_empty() {
+					continue;
+				}
+
+				// Ensure vehicle subdirectory exists
+				if !any_written {
+					if let Err(e) = std::fs::create_dir_all(&vehicle_dir) {
+						eprintln!("DIR ERROR {vehicle_id}: {e}");
+						failed += 1;
+						break;
+					}
+					any_written = true;
+				}
+
+				let filename = format!("{}.txt", proj.output_name);
+				let file_path = vehicle_dir.join(&filename);
+
+				if let Err(e) = std::fs::write(&file_path, &content) {
+					eprintln!("WRITE ERROR {vehicle_id}/{filename}: {e}");
+					failed += 1;
+				} else {
+					shells_written += 1;
+				}
+			}
+		}
+
+		if any_written {
+			processed += 1;
+		}
+	}
+
+	eprintln!();
+	eprintln!(
+		"Done: {processed} vehicles, {shells_written} shell tables written, {failed} errors"
+	);
+}

--- a/tools/fcsgen/cli/src/run.rs
+++ b/tools/fcsgen/cli/src/run.rs
@@ -1,0 +1,190 @@
+//! Unified `run` command: extract → convert → ballistic in one invocation.
+//!
+//! Replaces the old three-step CLI workflow (`extract` + `convert` + `ballistic`)
+//! with a single command that pipes data in-memory where possible.
+//!
+//! `Data/*.txt` files are still written (the C# sight generator reads them).
+//! `Ballistic/{vehicle}/{shell}.txt` files are still written.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use fcsgen_core::ballistic::{compute_ballistic, should_skip};
+use fcsgen_core::parser::data::from_projectile;
+use fcsgen_core::{convert_vehicle, emit_legacy_txt};
+
+use crate::extract;
+
+/// Configuration for the unified pipeline.
+pub struct PipelineConfig<'a> {
+	pub game_path: &'a Path,
+	pub output: &'a Path,
+	pub sensitivity: f64,
+	pub ignore_file: Option<&'a Path>,
+	pub filter: Option<&'a [String]>,
+	pub skip_extract: bool,
+	pub skip_ballistic: bool,
+}
+
+/// Run the full pipeline: extract → convert → ballistic.
+#[allow(clippy::too_many_lines)]
+pub fn run_pipeline(cfg: &PipelineConfig<'_>) {
+	let datamine_dir = cfg.output.join("Datamine");
+	let data_dir = cfg.output.join("Data");
+	let ballistic_dir = cfg.output.join("Ballistic");
+
+	// ── Step 1: Extract ────────────────────────────────────────────────
+	if cfg.skip_extract {
+		eprintln!("Step 1/3: Skipping extraction (--skip-extract)");
+	} else {
+		eprintln!("Step 1/3: Extracting datamine...");
+		extract::run_extract(cfg.game_path, &datamine_dir, cfg.ignore_file, false);
+	}
+
+	// ── Step 2+3: Convert + Ballistic (in-memory pipeline) ─────────────
+	let aces_root = datamine_dir.join("aces.vromfs.bin_u");
+	let tankmodels = aces_root.join("gamedata").join("units").join("tankmodels");
+
+	if !tankmodels.exists() {
+		eprintln!(
+			"Error: tankmodels directory not found at {}",
+			tankmodels.display()
+		);
+		eprintln!("Run without --skip-extract to populate the datamine first.");
+		std::process::exit(1);
+	}
+
+	// Create output directories
+	for dir in [&data_dir, &ballistic_dir] {
+		if let Err(e) = std::fs::create_dir_all(dir) {
+			eprintln!("Error: cannot create directory {}: {e}", dir.display());
+			std::process::exit(1);
+		}
+	}
+
+	// Collect vehicle files
+	let mut vehicles: Vec<_> = std::fs::read_dir(&tankmodels)
+		.expect("read tankmodels")
+		.filter_map(Result::ok)
+		.filter(|e| e.path().extension().is_some_and(|ext| ext == "blkx"))
+		.filter(|e| {
+			if let Some(filter) = cfg.filter {
+				let stem = e.path().file_stem().unwrap().to_string_lossy().to_string();
+				filter.iter().any(|f| f == &stem)
+			} else {
+				true
+			}
+		})
+		.collect();
+
+	vehicles.sort_by_key(std::fs::DirEntry::file_name);
+
+	let total = vehicles.len();
+	let mut converted = 0;
+	let mut skipped = 0;
+	let mut convert_failed = 0;
+	let mut shells_written = 0;
+	let mut ballistic_errors = 0;
+
+	eprintln!(
+		"Step 2/3: Converting {total} vehicles (+ ballistic, sensitivity={})",
+		cfg.sensitivity,
+	);
+	eprintln!("  Data:      {}", data_dir.display());
+	if !cfg.skip_ballistic {
+		eprintln!("  Ballistic: {}", ballistic_dir.display());
+	}
+	eprintln!();
+
+	for entry in &vehicles {
+		let path = entry.path();
+		let name = path.file_stem().unwrap().to_string_lossy().to_string();
+
+		// Convert vehicle from datamine
+		let data = match convert_vehicle(&path, &datamine_dir) {
+			Ok(d) => d,
+			Err(e) => {
+				eprintln!("CONVERT ERROR {name}: {e}");
+				convert_failed += 1;
+				continue;
+			},
+		};
+
+		if !data.is_armed() {
+			skipped += 1;
+			continue;
+		}
+
+		// Write Data/{vehicle}.txt (still needed by C# sight generator)
+		let txt = emit_legacy_txt(&data);
+		let data_path = data_dir.join(format!("{name}.txt"));
+		if let Err(e) = std::fs::write(&data_path, &txt) {
+			eprintln!("WRITE ERROR {name}: {e}");
+			convert_failed += 1;
+			continue;
+		}
+
+		converted += 1;
+
+		// ── In-memory ballistic computation ────────────────────────────
+		if cfg.skip_ballistic {
+			continue;
+		}
+
+		// Bridge Projectile → DataProjectile
+		let data_projectiles: Vec<_> = data
+			.projectiles
+			.iter()
+			.map(from_projectile)
+			.collect();
+
+		// Deduplicate by output_name: keep last occurrence (matching C#'s
+		// `File.WriteAllText` overwrite semantics).
+		let mut last_by_name: HashMap<String, usize> = HashMap::new();
+		for (idx, dp) in data_projectiles.iter().enumerate() {
+			if !should_skip(&dp.normalized_type) {
+				last_by_name.insert(dp.output_name.clone(), idx);
+			}
+		}
+
+		let vehicle_dir = ballistic_dir.join(&name);
+		let mut any_written = false;
+
+		for &idx in last_by_name.values() {
+			let dp = &data_projectiles[idx];
+
+			if let Some(content) = compute_ballistic(dp, cfg.sensitivity) {
+				if content.is_empty() {
+					continue;
+				}
+
+				// Ensure vehicle subdirectory exists
+				if !any_written {
+					if let Err(e) = std::fs::create_dir_all(&vehicle_dir) {
+						eprintln!("DIR ERROR {name}: {e}");
+						ballistic_errors += 1;
+						break;
+					}
+					any_written = true;
+				}
+
+				let filename = format!("{}.txt", dp.output_name);
+				let file_path = vehicle_dir.join(&filename);
+
+				if let Err(e) = std::fs::write(&file_path, &content) {
+					eprintln!("WRITE ERROR {name}/{filename}: {e}");
+					ballistic_errors += 1;
+				} else {
+					shells_written += 1;
+				}
+			}
+		}
+	}
+
+	eprintln!();
+	eprintln!("Done: {converted} converted, {skipped} skipped (unarmed), {convert_failed} convert errors");
+	if !cfg.skip_ballistic {
+		eprintln!("      {shells_written} ballistic tables written, {ballistic_errors} ballistic errors");
+	}
+}
+

--- a/tools/fcsgen/core/src/ballistic.rs
+++ b/tools/fcsgen/core/src/ballistic.rs
@@ -1,0 +1,329 @@
+//! Ballistic trajectory computation and penetration calculation.
+//!
+//! Implements the Euler-method trajectory simulation and `DeMarre` penetration
+//! formula, matching the C# `Ballistic()` method in Form1.cs.
+
+use std::f64::consts::PI;
+use std::fmt::Write;
+
+use crate::parser::data::DataProjectile;
+
+// ── Physics constants ──────────────────────────────────────────────────────
+const G: f64 = 9.806_65;
+const DT: f64 = 0.01;
+const P_ATM: f64 = 101_325.0;
+const T_GROUND: f64 = 15.0;
+const M_AIR: f64 = 0.028_965_2;
+const R_GAS: f64 = 8.314_46;
+const LAPSE_RATE: f64 = 0.0065;
+const T_STD: f64 = 288.15;
+const DEMARRE_REF_V: f64 = 1900.0;
+const MAX_RANGE: f64 = 4500.0;
+
+// ── DeMarre defaults (applied when the parsed value is zero) ───────────────
+const DEFAULT_K: f64 = 0.9;
+const DEFAULT_SPEED_POW: f64 = 1.43;
+const DEFAULT_MASS_POW: f64 = 0.71;
+const DEFAULT_CALIBER_POW: f64 = 1.07;
+
+// ── Shell type classification ──────────────────────────────────────────────
+const AP_TYPES: &[&str] = &[
+	"i", "t", "ac", "aphe", "aphebc", "ap", "sap", "sapi", "apc", "apbc",
+	"apcbc", "sapcbc",
+];
+const APHE_TYPES: &[&str] = &["aphe", "aphebc", "ac", "sapcbc", "sap", "sapi"];
+const SKIP_TYPES: &[&str] = &["sam", "atgm", "rocket", "aam"];
+
+// ── APHE explosive-filler penalty table (ratio threshold → multiplier) ─────
+const PEN_BY_EXPL: [(f64, f64); 5] = [
+	(0.0065, 1.0),
+	(0.016, 0.93),
+	(0.02, 0.9),
+	(0.03, 0.85),
+	(0.04, 0.75),
+];
+
+// ── APCR/APDS subcaliber mass-ratio table ──────────────────────────────────
+const PEN_BY_SUBCALIBER: [(f64, f64); 4] = [
+	(0.0, 0.25),
+	(0.15, 0.4),
+	(0.3, 0.5),
+	(0.4, 0.75),
+];
+
+/// Intermediate row produced by the trajectory simulation.
+struct Row {
+	distance: f64,
+	time: f64,
+	penetration: f64,
+}
+
+/// Returns `true` if this shell type should be skipped entirely.
+#[must_use]
+pub fn should_skip(normalized_type: &str) -> bool {
+	SKIP_TYPES.contains(&normalized_type)
+}
+
+/// Compute the ballistic table for a single projectile.
+///
+/// Returns the TSV-formatted output string (`distance\ttime\tpenetration\n`
+/// per line), or `None` if the projectile type is skipped.
+#[must_use]
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
+pub fn compute_ballistic(proj: &DataProjectile, sensitivity: f64) -> Option<String> {
+	if should_skip(&proj.normalized_type) || sensitivity <= 0.0 {
+		return None;
+	}
+
+	// DeMarre parameters with defaults applied
+	let k = non_zero_or(proj.demarre_k, DEFAULT_K);
+	let speed_pow = non_zero_or(proj.demarre_speed_pow, DEFAULT_SPEED_POW);
+	let mass_pow = non_zero_or(proj.demarre_mass_pow, DEFAULT_MASS_POW);
+	let caliber_pow = non_zero_or(proj.demarre_caliber_pow, DEFAULT_CALIBER_POW);
+
+	let scroll_step = 2.8 * sensitivity * sensitivity;
+	let max_entries = (PI / 180.0 * 60.0 * 1000.0 / scroll_step).floor() as usize;
+
+	// Pre-computed barometric exponent (constant for a given atmosphere).
+	let baro_exp = G * M_AIR / R_GAS / LAPSE_RATE - 1.0;
+	let temp_kelvin = T_GROUND + 273.15;
+
+	let ntype = proj.normalized_type.as_str();
+	let is_ap = AP_TYPES.contains(&ntype);
+	let is_aphe = APHE_TYPES.contains(&ntype);
+	let is_subcaliber = ntype == "apcr" || ntype == "apds";
+	let is_apds_fs = ntype == "apds_fs";
+
+	let mut rows: Vec<Row> = Vec::with_capacity(max_entries.min(512));
+	let mut last_distance = 0.0_f64;
+
+	for i in 0..max_entries {
+		if last_distance >= MAX_RANGE {
+			break;
+		}
+
+		let angle = scroll_step * (i as f64) / 1000.0;
+		let mut vx = proj.speed * angle.cos();
+		let mut vy = proj.speed * angle.sin();
+		let (mut x, mut y, mut t) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut x0, mut y0) = (0.0_f64, 0.0_f64);
+
+		while y >= 0.0 {
+			let ro = P_ATM * M_AIR / R_GAS / temp_kelvin
+				* (1.0 - LAPSE_RATE * y / T_STD).powf(baro_exp);
+
+			let v_sq = vx * vx + vy * vy;
+			let drag =
+				proj.cx * ro * v_sq / 2.0 * proj.ballistic_caliber.powi(2) / 4.0 * PI;
+			let accel = drag / proj.mass;
+
+			// NOTE: vx is updated *first*; the vy update sees the new vx when
+			// evaluating atan(vy/vx).  This matches the C# evaluation order.
+			let a1 = (vy / vx).atan();
+			vx += (-accel * a1.cos()) * DT;
+
+			let a2 = (vy / vx).atan(); // uses updated vx, original vy
+			vy += (-G - accel * a2.sin()) * DT;
+
+			t += DT;
+			x0 = x;
+			y0 = y;
+			x += vx * DT;
+			y += vy * DT;
+		}
+
+		// Interpolate the ground-crossing distance.
+		let distance = x0 + (x - x0) / (y - y0) * (-y0);
+		last_distance = distance;
+
+		let time = (t * 10.0).round() / 10.0; // 1-decimal, away-from-zero
+		let v_impact = (vx * vx + vy * vy).sqrt();
+
+		let penetration = if is_ap {
+			let mut pen = k
+				* (v_impact / DEMARRE_REF_V).powf(speed_pow)
+				* proj.mass.powf(mass_pow)
+				/ (proj.ballistic_caliber * 10.0).powf(caliber_pow)
+				* 100.0;
+
+			if is_aphe {
+				pen *= aphe_penalty(proj.explosive_mass / proj.mass);
+			}
+			pen.round()
+		} else if is_subcaliber {
+			let ratio = proj.damage_mass / proj.mass;
+			let sub_k = interpolate_table(&PEN_BY_SUBCALIBER, ratio);
+			let effective_mass =
+				(proj.mass - proj.damage_mass) * sub_k + proj.damage_mass;
+
+			(k * (v_impact / DEMARRE_REF_V).powf(speed_pow)
+				* effective_mass.powf(mass_pow)
+				/ (proj.damage_caliber * 10.0).powf(caliber_pow)
+				* 100.0)
+				.round()
+		} else if is_apds_fs {
+			interpolate_armor_power(&proj.armor_power_table, distance).round()
+		} else {
+			0.0
+		};
+
+		rows.push(Row {
+			distance,
+			time,
+			penetration,
+		});
+	}
+
+	// Emit TSV.  Output every row except the last, stopping early on a
+	// distance decrease (monotonicity guard, matches C# output loop).
+	let mut out = String::new();
+	if rows.len() >= 2 {
+		for i in 0..rows.len() - 1 {
+			if rows[i + 1].distance < rows[i].distance {
+				break;
+			}
+			writeln!(
+				out,
+				"{:.3}\t{}\t{}",
+				rows[i].distance,
+				fmt_time(rows[i].time),
+				fmt_penetration(rows[i].penetration),
+			)
+			.unwrap();
+		}
+	}
+
+	Some(out)
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/// APHE explosive-filler penalty factor.
+fn aphe_penalty(k: f64) -> f64 {
+	interpolate_table(&PEN_BY_EXPL, k)
+}
+
+/// Piecewise-linear table lookup matching the C# pattern.
+///
+/// - Below the first threshold → returns the first value.
+/// - Above the last threshold → returns the last value.
+/// - Between thresholds → linearly interpolates.
+fn interpolate_table(table: &[(f64, f64)], k: f64) -> f64 {
+	if k < table[0].0 {
+		return table[0].1;
+	}
+	for window in table.windows(2) {
+		let (x0, y0) = window[0];
+		let (x1, y1) = window[1];
+		if k >= x0 && k < x1 {
+			return y0 + (y1 - y0) / (x1 - x0) * (k - x0);
+		}
+	}
+	table[table.len() - 1].1
+}
+
+/// Linear interpolation of the APDS-FS armor-power table.
+///
+/// Returns 0 when the distance falls outside all intervals (this includes
+/// the case where the table is empty — i.e. no APDS series was present in
+/// the data file).
+fn interpolate_armor_power(table: &[(f64, f64)], distance: f64) -> f64 {
+	for window in table.windows(2) {
+		let (d0, p0) = window[0];
+		let (d1, p1) = window[1];
+		if distance >= d0 && distance < d1 {
+			return p0 + (distance - d0) / (d1 - d0) * (p1 - p0);
+		}
+	}
+	0.0
+}
+
+/// Format time for TSV output, matching C# `double.ToString()` behaviour.
+///
+/// Whole-second values have no decimal point: `"0"`, `"1"`, `"10"`.
+/// Fractional values get exactly one decimal: `"0.1"`, `"3.5"`.
+#[allow(clippy::cast_possible_truncation)]
+fn fmt_time(t: f64) -> String {
+	if t.fract().abs() < 1e-9 {
+		format!("{}", t as i64)
+	} else {
+		format!("{t:.1}")
+	}
+}
+
+/// Format penetration for TSV output, matching C# `double.ToString()`.
+///
+/// Finite values are integers: `"138"`, `"0"`.
+/// Infinite values are the infinity symbol: `"∞"` (matches C# behaviour).
+#[allow(clippy::cast_possible_truncation)]
+fn fmt_penetration(p: f64) -> String {
+	if p.is_infinite() || p.is_nan() {
+		"\u{221E}".to_owned() // ∞
+	} else {
+		format!("{}", p as i64)
+	}
+}
+
+/// Return `val` when it is non-zero, otherwise `default`.
+fn non_zero_or(val: f64, default: f64) -> f64 {
+	if val == 0.0 { default } else { val }
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_interpolate_table_below() {
+		assert!((interpolate_table(&PEN_BY_EXPL, 0.001) - 1.0).abs() < f64::EPSILON);
+	}
+
+	#[test]
+	fn test_interpolate_table_above() {
+		assert!((interpolate_table(&PEN_BY_EXPL, 0.05) - 0.75).abs() < f64::EPSILON);
+	}
+
+	#[test]
+	fn test_interpolate_table_middle() {
+		// Between (0.0065, 1.0) and (0.016, 0.93)
+		let k = 0.01;
+		let expected = 1.0 + (0.93 - 1.0) / (0.016 - 0.0065) * (0.01 - 0.0065);
+		assert!((interpolate_table(&PEN_BY_EXPL, k) - expected).abs() < 1e-10);
+	}
+
+	#[test]
+	fn test_interpolate_subcaliber() {
+		// k = 0.0 → 0.25
+		assert!((interpolate_table(&PEN_BY_SUBCALIBER, 0.0) - 0.25).abs() < f64::EPSILON);
+		// k = 0.4 → 0.75
+		assert!((interpolate_table(&PEN_BY_SUBCALIBER, 0.4) - 0.75).abs() < f64::EPSILON);
+		// k = 0.5 → 0.75 (above last)
+		assert!((interpolate_table(&PEN_BY_SUBCALIBER, 0.5) - 0.75).abs() < f64::EPSILON);
+	}
+
+	#[test]
+	fn test_fmt_time() {
+		assert_eq!(fmt_time(0.0), "0");
+		assert_eq!(fmt_time(1.0), "1");
+		assert_eq!(fmt_time(10.0), "10");
+		assert_eq!(fmt_time(0.1), "0.1");
+		assert_eq!(fmt_time(3.5), "3.5");
+	}
+
+	#[test]
+	fn test_should_skip() {
+		assert!(should_skip("atgm"));
+		assert!(should_skip("sam"));
+		assert!(should_skip("rocket"));
+		assert!(should_skip("aam"));
+		assert!(!should_skip("apcbc"));
+		assert!(!should_skip("he"));
+		assert!(!should_skip("apds_fs"));
+	}
+
+	#[test]
+	fn test_non_zero_or() {
+		assert!((non_zero_or(0.0, 0.9) - 0.9).abs() < f64::EPSILON);
+		assert!((non_zero_or(1.0, 0.9) - 1.0).abs() < f64::EPSILON);
+	}
+}

--- a/tools/fcsgen/core/src/emit/legacy.rs
+++ b/tools/fcsgen/core/src/emit/legacy.rs
@@ -160,8 +160,6 @@ mod tests {
 			rocket_paths: vec![],
 			zoom_in: Some(6.0),
 			zoom_out: Some(30.0),
-			zoom_in_2: None,
-			zoom_out_2: None,
 			has_laser: true,
 			projectiles: vec![Projectile {
 				name: "test_shell".to_string(),

--- a/tools/fcsgen/core/src/model.rs
+++ b/tools/fcsgen/core/src/model.rs
@@ -23,12 +23,6 @@ pub struct VehicleData {
 	/// Primary optics zoom (wide FOV, lower magnification).
 	pub zoom_out: Option<f64>,
 
-	/// Secondary optics zoom (narrow FOV), if present.
-	pub zoom_in_2: Option<f64>,
-
-	/// Secondary optics zoom (wide FOV), if present.
-	pub zoom_out_2: Option<f64>,
-
 	/// Whether the vehicle has a laser rangefinder.
 	pub has_laser: bool,
 
@@ -115,8 +109,6 @@ impl VehicleData {
 			rocket_paths: Vec::new(),
 			zoom_in: None,
 			zoom_out: None,
-			zoom_in_2: None,
-			zoom_out_2: None,
 			has_laser: false,
 			projectiles: Vec::new(),
 		}

--- a/tools/fcsgen/core/src/parser/data.rs
+++ b/tools/fcsgen/core/src/parser/data.rs
@@ -1,0 +1,437 @@
+//! Parser for the legacy `Data/{vehicle}.txt` intermediate format.
+//!
+//! Reads the key:value text files produced by `fcsgen convert` (Stage 1)
+//! back into structured data for use by the ballistic computation (Stage 2).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::model::{ArmorPowerSeries, Projectile};
+
+/// Parsed vehicle data from a `Data/{vehicle}.txt` file.
+#[derive(Debug, Clone)]
+pub struct DataFile {
+	/// Vehicle identifier (filename stem).
+	pub vehicle_id: String,
+
+	/// Path to the primary weapon module.
+	pub weapon_path: Option<String>,
+
+	/// Rocket/ATGM module paths.
+	pub rocket_paths: Vec<String>,
+
+	/// Primary optics zoom (narrow FOV).
+	pub zoom_in: Option<f64>,
+
+	/// Primary optics zoom (wide FOV).
+	pub zoom_out: Option<f64>,
+
+	/// Whether the vehicle has a laser rangefinder.
+	pub has_laser: bool,
+
+	/// Parsed projectile blocks.
+	pub projectiles: Vec<DataProjectile>,
+}
+
+/// A single projectile block from a `Data/{vehicle}.txt` file.
+#[derive(Debug, Clone)]
+pub struct DataProjectile {
+	/// Full projectile name (e.g. `105mm_m735`).
+	pub name: String,
+
+	/// Raw type string (e.g. `apds_fs_tungsten_l10_l15_tank`).
+	pub bullet_type: String,
+
+	/// Normalized type for ballistic computation.
+	///
+	/// If the raw type contains `apds_fs`, this is `apds_fs`.
+	/// Otherwise it is the first `_`-delimited segment (e.g. "apcbc", "he", "heat").
+	pub normalized_type: String,
+
+	/// Projectile mass in kg.
+	pub mass: f64,
+
+	/// Ballistic caliber in meters.
+	pub ballistic_caliber: f64,
+
+	/// Muzzle velocity in m/s.
+	pub speed: f64,
+
+	/// Drag coefficient.
+	pub cx: f64,
+
+	/// Explosive filler mass in kg.
+	pub explosive_mass: f64,
+
+	/// Sub-caliber core mass in kg (APCR/APDS).
+	pub damage_mass: f64,
+
+	/// Sub-caliber core caliber in meters (APCR/APDS).
+	pub damage_caliber: f64,
+
+	/// `DeMarre` penetration coefficient K.
+	pub demarre_k: f64,
+
+	/// `DeMarre` speed exponent.
+	pub demarre_speed_pow: f64,
+
+	/// `DeMarre` mass exponent.
+	pub demarre_mass_pow: f64,
+
+	/// `DeMarre` caliber exponent.
+	pub demarre_caliber_pow: f64,
+
+	/// APDS-FS armor power lookup table: `(distance_m, penetration_mm)` pairs.
+	///
+	/// Populated from `APDS{distance}:{penetration}` lines in the data file.
+	/// Empty for non-APDS-FS types.
+	pub armor_power_table: Vec<(f64, f64)>,
+
+	/// Shell name cleaned for output filename.
+	///
+	/// Caliber prefix (everything up to and including "mm_") is stripped.
+	/// Everything after "/" is removed.
+	pub output_name: String,
+}
+
+/// Parse a `Data/{vehicle}.txt` file from disk.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read.
+pub fn parse_data_file(path: &Path) -> std::io::Result<DataFile> {
+	let content = std::fs::read_to_string(path)?;
+	let vehicle_id = path
+		.file_stem()
+		.and_then(|s| s.to_str())
+		.unwrap_or("unknown")
+		.to_owned();
+
+	Ok(parse_data_text(&content, &vehicle_id))
+}
+
+/// Parse a `Data/{vehicle}.txt` from a string.
+#[must_use]
+pub fn parse_data_text(content: &str, vehicle_id: &str) -> DataFile {
+	let content = content.replace("\r\n", "\n");
+	let mut weapon_path = None;
+	let mut rocket_paths = Vec::new();
+	let mut zoom_in = None;
+	let mut zoom_out = None;
+	let mut has_laser = false;
+	let mut projectiles = Vec::new();
+
+	// Split into sections by blank lines
+	let sections: Vec<&str> = content.split("\n\n").collect();
+
+	// First section is the header
+	if let Some(header) = sections.first() {
+		for line in header.lines() {
+			let line = line.trim();
+			if let Some((key, value)) = line.split_once(':') {
+				match key {
+					"WeaponPath" => weapon_path = Some(value.to_owned()),
+					"RocketPath" => rocket_paths.push(value.to_owned()),
+					"ZoomIn" => zoom_in = value.parse().ok(),
+					"ZoomOut" => zoom_out = value.parse().ok(),
+					_ => {},
+				}
+			} else if line == "HasLaser" {
+				has_laser = true;
+			}
+		}
+	}
+
+	// Remaining sections are projectile blocks
+	for section in sections.iter().skip(1) {
+		if let Some(proj) = parse_projectile_block(section) {
+			projectiles.push(proj);
+		}
+	}
+
+	DataFile {
+		vehicle_id: vehicle_id.to_owned(),
+		weapon_path,
+		rocket_paths,
+		zoom_in,
+		zoom_out,
+		has_laser,
+		projectiles,
+	}
+}
+
+/// Parse a single projectile block (lines between blank lines).
+fn parse_projectile_block(block: &str) -> Option<DataProjectile> {
+	let mut fields: HashMap<&str, &str> = HashMap::new();
+	let mut apds_entries: Vec<(f64, f64)> = Vec::new();
+
+	for line in block.lines() {
+		let line = line.trim();
+		if line.is_empty() {
+			continue;
+		}
+		if let Some((key, value)) = line.split_once(':') {
+			// Check for APDS distance-penetration entries (e.g. "APDS0:292.4")
+			if key.starts_with("APDS") {
+				if let Some(dist_str) = key.strip_prefix("APDS")
+					&& let (Ok(dist), Ok(pen)) = (dist_str.parse::<f64>(), value.parse::<f64>())
+				{
+					apds_entries.push((dist, pen));
+				}
+			} else {
+				fields.insert(key, value);
+			}
+		}
+	}
+
+	let name = (*fields.get("Name")?).to_owned();
+	let bullet_type = fields.get("Type").copied().unwrap_or("").to_owned();
+
+	// Normalize type for ballistic computation (matches C# logic)
+	let normalized_type = normalize_shell_type(&bullet_type);
+
+	// Parse numeric fields with 0.0 defaults
+	let mass = parse_f64(fields.get("BulletMass").copied());
+	let ballistic_caliber = parse_f64(fields.get("BallisticCaliber").copied());
+	let speed = parse_f64(fields.get("Speed").copied());
+	let cx = parse_f64(fields.get("Cx").copied());
+	let explosive_mass = parse_f64(fields.get("ExplosiveMass").copied());
+	let damage_mass = parse_f64(fields.get("DamageMass").copied());
+	let damage_caliber = parse_f64(fields.get("DamageCaliber").copied());
+	let demarre_k = parse_f64(fields.get("demarrePenetrationK").copied());
+	let demarre_speed_pow = parse_f64(fields.get("demarreSpeedPow").copied());
+	let demarre_mass_pow = parse_f64(fields.get("demarreMassPow").copied());
+	let demarre_caliber_pow = parse_f64(fields.get("demarreCaliberPow").copied());
+
+	// Sort APDS entries by distance for correct interpolation
+	apds_entries.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+	// Build output name: strip caliber prefix and path suffix
+	let output_name = clean_shell_name(&name);
+
+	Some(DataProjectile {
+		name,
+		bullet_type,
+		normalized_type,
+		mass,
+		ballistic_caliber,
+		speed,
+		cx,
+		explosive_mass,
+		damage_mass,
+		damage_caliber,
+		demarre_k,
+		demarre_speed_pow,
+		demarre_mass_pow,
+		demarre_caliber_pow,
+		armor_power_table: apds_entries,
+		output_name,
+	})
+}
+
+/// Normalize the shell type string for ballistic computation.
+///
+/// Matches the C# logic:
+/// - If the type contains `apds_fs`, return `apds_fs`
+/// - Otherwise take the first underscore-delimited segment
+#[must_use]
+pub fn normalize_shell_type(raw_type: &str) -> String {
+	if raw_type.contains("apds_fs") {
+		return "apds_fs".to_owned();
+	}
+	raw_type
+		.split('_')
+		.next()
+		.unwrap_or("")
+		.to_owned()
+}
+
+/// Clean a shell name for use as an output filename.
+///
+/// Strips the caliber prefix (everything up to and including "mm_")
+/// and removes everything after "/" (matching C# `BulletName` cleanup).
+#[must_use]
+pub fn clean_shell_name(name: &str) -> String {
+	// Strip everything after "/" first
+	let name = name.split('/').next().unwrap_or(name);
+
+	// Strip caliber prefix (everything up to and including "mm_")
+	if let Some(pos) = name.find("mm_") {
+		name[pos + 3..].to_owned()
+	} else {
+		name.to_owned()
+	}
+}
+
+/// Parse a string as f64, returning 0.0 on failure or None.
+fn parse_f64(s: Option<&str>) -> f64 {
+	s.and_then(|v| v.parse().ok()).unwrap_or(0.0)
+}
+
+/// Default Cx value for projectiles without an explicit drag coefficient.
+///
+/// Matches the legacy emitter behaviour: rockets/ATGMs and other shells
+/// missing a Cx field get 0.38 written into `Data/*.txt`.
+const DEFAULT_CX: f64 = 0.38;
+
+/// Fixed distance steps for the `ArmorPowerSeries` → table conversion.
+#[allow(clippy::type_complexity)]
+const ARMOR_POWER_DISTANCES: [(f64, fn(&ArmorPowerSeries) -> Option<f64>); 12] = [
+	(0.0, |s| s.ap_0m),
+	(100.0, |s| s.ap_100m),
+	(500.0, |s| s.ap_500m),
+	(1000.0, |s| s.ap_1000m),
+	(1500.0, |s| s.ap_1500m),
+	(2000.0, |s| s.ap_2000m),
+	(2500.0, |s| s.ap_2500m),
+	(3000.0, |s| s.ap_3000m),
+	(3500.0, |s| s.ap_3500m),
+	(4000.0, |s| s.ap_4000m),
+	(4500.0, |s| s.ap_4500m),
+	(10000.0, |s| s.ap_10000m),
+];
+
+/// Convert a [`Projectile`] (Stage 1 model) directly into a [`DataProjectile`]
+/// (Stage 2 model) without going through the text roundtrip.
+///
+/// This bridges the in-memory pipeline: `convert_vehicle` produces
+/// `VehicleData` with `Projectile` entries; this function converts each
+/// into the flat `DataProjectile` that [`compute_ballistic`] expects.
+///
+/// The conversion faithfully reproduces the same defaulting and
+/// transformation logic that would occur if the data were serialised
+/// via `emit_legacy_txt` and re-parsed via `parse_data_text`.
+///
+/// [`compute_ballistic`]: crate::ballistic::compute_ballistic
+#[must_use]
+pub fn from_projectile(proj: &Projectile) -> DataProjectile {
+	let normalized_type = normalize_shell_type(&proj.bullet_type);
+	let output_name = clean_shell_name(&proj.name);
+
+	// Flatten DeMarre parameters (0.0 when absent — ballistic.rs applies
+	// its own non-zero defaults at compute time).
+	let (demarre_k, demarre_speed_pow, demarre_mass_pow, demarre_caliber_pow) =
+		proj.demarre.as_ref().map_or(
+			(0.0, 0.0, 0.0, 0.0),
+			|d| (d.k, d.speed_pow, d.mass_pow, d.caliber_pow),
+		);
+
+	// Build APDS armor power table from the named series fields.
+	let armor_power_table = proj
+		.armor_power_series
+		.as_ref()
+		.map_or_else(Vec::new, |series| {
+			ARMOR_POWER_DISTANCES
+				.iter()
+				.filter_map(|&(dist, getter)| getter(series).map(|pen| (dist, pen)))
+				.collect()
+		});
+
+	DataProjectile {
+		name: proj.name.clone(),
+		bullet_type: proj.bullet_type.clone(),
+		normalized_type,
+		mass: proj.mass.unwrap_or(0.0),
+		ballistic_caliber: proj.ballistic_caliber.unwrap_or(0.0),
+		speed: proj.speed.unwrap_or(0.0),
+		cx: proj.cx.unwrap_or(DEFAULT_CX),
+		explosive_mass: proj.explosive_mass.unwrap_or(0.0),
+		damage_mass: proj.damage_mass.unwrap_or(0.0),
+		damage_caliber: proj.damage_caliber.unwrap_or(0.0),
+		demarre_k,
+		demarre_speed_pow,
+		demarre_mass_pow,
+		demarre_caliber_pow,
+		armor_power_table,
+		output_name,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_normalize_shell_type() {
+		assert_eq!(normalize_shell_type("apcbc_tank"), "apcbc");
+		assert_eq!(normalize_shell_type("he_frag_tank"), "he");
+		assert_eq!(normalize_shell_type("heat_fs_tank"), "heat");
+		assert_eq!(normalize_shell_type("apds_fs_long_tank"), "apds_fs");
+		assert_eq!(normalize_shell_type("apds_fs_tungsten_l10_l15_tank"), "apds_fs");
+		assert_eq!(normalize_shell_type("apcr_tank"), "apcr");
+		assert_eq!(normalize_shell_type("apds_autocannon"), "apds");
+		assert_eq!(normalize_shell_type("atgm_tandem_tank"), "atgm");
+		assert_eq!(normalize_shell_type("smoke_tank"), "smoke");
+	}
+
+	#[test]
+	fn test_clean_shell_name() {
+		assert_eq!(clean_shell_name("75mm_pzgr_39"), "pzgr_39");
+		assert_eq!(clean_shell_name("105mm_m735"), "m735");
+		assert_eq!(clean_shell_name("120mm_m829a2"), "m829a2");
+		assert_eq!(clean_shell_name("30mm_UBR6"), "UBR6");
+		assert_eq!(clean_shell_name("some_bullet"), "some_bullet");
+		assert_eq!(clean_shell_name("105mm_m735/something"), "m735");
+	}
+
+	#[test]
+	fn test_parse_data_text() {
+		let content = "\
+WeaponPath:gameData/Weapons/test.blkx
+ZoomIn:9.21
+ZoomOut:28.63
+HasLaser
+
+Name:105mm_m735
+Type:apds_fs_tungsten_l10_l15_tank
+BulletMass:3.719457
+BallisticCaliber:0.035
+Speed:1501.14
+Cx:0.2925
+DamageCaliber:0.03175
+APDS0:292.4
+APDS100:290.6
+APDS500:284.0
+APDS1000:275.0
+APDS1500:265.9
+APDS2000:256.5
+APDS2500:246.7
+APDS3000:236.7
+APDS4000:215.5
+APDS10000:50.0
+
+Name:75mm_pzgr_39
+Type:apcbc_tank
+BulletMass:6.8
+BallisticCaliber:0.075
+Speed:740.0
+Cx:0.4
+ExplosiveMass:0.017
+ExplosiveType:h10
+demarrePenetrationK:1.0
+demarreSpeedPow:1.43
+demarreMassPow:0.71
+demarreCaliberPow:1.07";
+
+		let data = parse_data_text(content, "test_vehicle");
+
+		assert_eq!(data.vehicle_id, "test_vehicle");
+		assert_eq!(data.weapon_path.as_deref(), Some("gameData/Weapons/test.blkx"));
+		assert!(data.has_laser);
+		assert_eq!(data.zoom_in, Some(9.21));
+		assert_eq!(data.projectiles.len(), 2);
+
+		let m735 = &data.projectiles[0];
+		assert_eq!(m735.output_name, "m735");
+		assert_eq!(m735.normalized_type, "apds_fs");
+		assert_eq!(m735.armor_power_table.len(), 10);
+		assert!((m735.armor_power_table[0].0 - 0.0).abs() < f64::EPSILON);
+		assert!((m735.armor_power_table[0].1 - 292.4).abs() < f64::EPSILON);
+
+		let pzgr = &data.projectiles[1];
+		assert_eq!(pzgr.output_name, "pzgr_39");
+		assert_eq!(pzgr.normalized_type, "apcbc");
+		assert!((pzgr.demarre_k - 1.0).abs() < f64::EPSILON);
+		assert!((pzgr.explosive_mass - 0.017).abs() < f64::EPSILON);
+	}
+}

--- a/tools/fcsgen/core/src/parser/mod.rs
+++ b/tools/fcsgen/core/src/parser/mod.rs
@@ -1,5 +1,6 @@
 //! Parser for War Thunder datamine files.
 
+pub mod data;
 pub mod vehicle;
 pub mod weapon;
 

--- a/tools/fcsgen/core/src/parser/vehicle.rs
+++ b/tools/fcsgen/core/src/parser/vehicle.rs
@@ -50,19 +50,6 @@ pub fn parse_vehicle(json: &Value, vehicle_id: &str) -> Result<VehicleData> {
 					classify_weapons(&weapons, &mut data);
 				}
 
-				// Check for modification-provided secondary optics (e.g., "bmp_3_upgrade_modification")
-				// Legacy code hits any "cockpit": in the file via line scanning; the second
-				// occurrence produces ZoomIn2/ZoomOut2 used for _ModOptic.txt emission.
-				if data.zoom_in_2.is_none() {
-					if let Some(cockpit @ Value::Object(_)) = effects.get("cockpit") {
-						data.zoom_in_2 = extract_fov_value(
-							cockpit.as_object().and_then(|o| o.get("zoomInFov")),
-						);
-						data.zoom_out_2 = extract_fov_value(
-							cockpit.as_object().and_then(|o| o.get("zoomOutFov")),
-						);
-					}
-				}
 			}
 		}
 	}
@@ -84,12 +71,9 @@ fn extract_zoom_values(cockpit: &Value, data: &mut VehicleData) {
 				data.zoom_in = extract_fov_value(obj.get("zoomInFov"));
 				data.zoom_out = extract_fov_value(obj.get("zoomOutFov"));
 			}
-			// Second cockpit is secondary optics
-			if let Some(Value::Object(obj)) = arr.get(1) {
-				data.zoom_in_2 = extract_fov_value(obj.get("zoomInFov"));
-				data.zoom_out_2 = extract_fov_value(obj.get("zoomOutFov"));
-			}
 		},
+		// Note: secondary cockpit optics (previously zoom_in_2/zoom_out_2 for
+		// ModOptic emission) are intentionally ignored — not a real game feature.
 		_ => {},
 	}
 }

--- a/tools/fcsgen/core/tests/stage2.rs
+++ b/tools/fcsgen/core/tests/stage2.rs
@@ -1,0 +1,237 @@
+//! Integration tests for Stage 2 ballistic computation.
+//!
+//! Parses every `Data/{vehicle}.txt` file, computes ballistic tables for each
+//! projectile, and compares the TSV output against the expected reference files
+//! in `test_data/expected/ballistic/{vehicle}/{shell}.txt`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use fcsgen_core::ballistic::{compute_ballistic, should_skip};
+use fcsgen_core::parser::data::parse_data_file;
+
+/// Default sensitivity used when generating the reference data.
+const SENSITIVITY: f64 = 0.50;
+
+/// Get the path to the test_data directory.
+fn test_data_dir() -> PathBuf {
+	PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+		.parent()
+		.unwrap()
+		.join("test_data")
+}
+
+/// Compare a computed ballistic TSV against the expected reference.
+///
+/// Returns `Ok(())` on exact match, `Err(description)` on mismatch.
+fn compare_ballistic(
+	vehicle: &str,
+	shell: &str,
+	computed: &str,
+	expected: &str,
+) -> Result<(), String> {
+	let computed = computed.replace("\r\n", "\n");
+	let expected = expected.replace("\r\n", "\n");
+
+	let comp_lines: Vec<&str> = computed.lines().collect();
+	let exp_lines: Vec<&str> = expected.lines().collect();
+
+	if comp_lines.len() != exp_lines.len() {
+		return Err(format!(
+			"{vehicle}/{shell}: line count mismatch: expected {}, got {}",
+			exp_lines.len(),
+			comp_lines.len(),
+		));
+	}
+
+	for (i, (cl, el)) in comp_lines.iter().zip(exp_lines.iter()).enumerate() {
+		if cl != el {
+			return Err(format!(
+				"{vehicle}/{shell} line {}: expected '{el}', got '{cl}'",
+				i + 1,
+			));
+		}
+	}
+
+	Ok(())
+}
+
+/// Run ballistic computation on ALL vehicles in the corpus and report statistics.
+#[test]
+fn test_ballistic_corpus() {
+	let data_dir = test_data_dir().join("expected").join("data");
+	let ballistic_dir = test_data_dir().join("expected").join("ballistic");
+	let output_dir = test_data_dir().join("output").join("ballistic");
+
+	if !data_dir.exists() {
+		eprintln!("Skipping ballistic corpus test: data directory not present");
+		return;
+	}
+
+	if !ballistic_dir.exists() {
+		eprintln!("Skipping ballistic corpus test: ballistic reference not present");
+		return;
+	}
+
+	// Ensure output directory exists (for debug output)
+	let _ = std::fs::create_dir_all(&output_dir);
+
+	// Collect data files
+	let mut data_files: Vec<_> = std::fs::read_dir(&data_dir)
+		.expect("read data dir")
+		.filter_map(|e| e.ok())
+		.filter(|e| e.path().extension().is_some_and(|ext| ext == "txt"))
+		.collect();
+
+	data_files.sort_by_key(std::fs::DirEntry::file_name);
+
+	let mut total_shells = 0;
+	let mut passed = 0;
+	let mut failed = 0;
+	let mut missing_expected = 0;
+	let mut errors = 0;
+	let mut failures: Vec<String> = Vec::new();
+
+	for entry in &data_files {
+		let path = entry.path();
+		let vehicle_id = path.file_stem().unwrap().to_string_lossy().to_string();
+
+		// Check if there's a corresponding ballistic directory
+		let vehicle_ballistic_dir = ballistic_dir.join(&vehicle_id);
+		if !vehicle_ballistic_dir.exists() {
+			// No expected ballistic output for this vehicle (e.g. pure SAM/ATGM)
+			continue;
+		}
+
+		let data = match parse_data_file(&path) {
+			Ok(d) => d,
+			Err(e) => {
+				eprintln!("PARSE ERROR {vehicle_id}: {e}");
+				errors += 1;
+				continue;
+			},
+		};
+
+		// Deduplicate projectiles: keep only the last occurrence of each
+		// output_name, matching C#'s File.WriteAllText overwrite behaviour.
+		let mut last_by_name: HashMap<String, usize> = HashMap::new();
+		for (idx, proj) in data.projectiles.iter().enumerate() {
+			if !should_skip(&proj.normalized_type) {
+				last_by_name.insert(proj.output_name.clone(), idx);
+			}
+		}
+
+		for &idx in last_by_name.values() {
+			let proj = &data.projectiles[idx];
+
+			let expected_path = vehicle_ballistic_dir.join(format!("{}.txt", proj.output_name));
+			if !expected_path.exists() {
+				missing_expected += 1;
+				continue;
+			}
+
+			total_shells += 1;
+
+			let computed = match compute_ballistic(proj, SENSITIVITY) {
+				Some(c) => c,
+				None => {
+					failures.push(format!(
+						"{vehicle_id}/{}: compute returned None",
+						proj.output_name
+					));
+					failed += 1;
+					continue;
+				},
+			};
+
+			let expected = match std::fs::read_to_string(&expected_path) {
+				Ok(e) => e,
+				Err(e) => {
+					eprintln!(
+						"READ ERROR {vehicle_id}/{}: {e}",
+						proj.output_name
+					);
+					errors += 1;
+					continue;
+				},
+			};
+
+			match compare_ballistic(&vehicle_id, &proj.output_name, &computed, &expected) {
+				Ok(()) => passed += 1,
+				Err(msg) => {
+					failed += 1;
+					failures.push(msg);
+
+					// Write computed output for debugging
+					let out_vehicle = output_dir.join(&vehicle_id);
+					let _ = std::fs::create_dir_all(&out_vehicle);
+					let _ = std::fs::write(
+						out_vehicle.join(format!("{}.txt", proj.output_name)),
+						&computed,
+					);
+				},
+			}
+		}
+	}
+
+	// Print summary
+	eprintln!("\n{}", "=".repeat(60));
+	eprintln!("BALLISTIC CORPUS TEST RESULTS");
+	eprintln!("{}", "=".repeat(60));
+	eprintln!("Total shells tested: {total_shells}");
+	eprintln!(
+		"Passed: {passed} ({:.1}%)",
+		if total_shells > 0 {
+			100.0 * passed as f64 / total_shells as f64
+		} else {
+			0.0
+		}
+	);
+	eprintln!(
+		"Failed: {failed} ({:.1}%)",
+		if total_shells > 0 {
+			100.0 * failed as f64 / total_shells as f64
+		} else {
+			0.0
+		}
+	);
+	eprintln!("Errors: {errors}");
+	eprintln!("Missing expected: {missing_expected}");
+
+	if !failures.is_empty() {
+		eprintln!("\nFirst 30 failures:");
+		for f in failures.iter().take(30) {
+			eprintln!("  {f}");
+		}
+
+		// Dump full failure list
+		let failure_log = test_data_dir()
+			.join("output")
+			.join("ballistic-failures.txt");
+		let mut report = String::new();
+		report.push_str("Ballistic Corpus Test Failure Report\n");
+		report.push_str(&"=".repeat(40));
+		report.push('\n');
+		report.push_str(&format!(
+			"Total: {total_shells}  Passed: {passed}  Failed: {failed}  Errors: {errors}\n\n"
+		));
+		for f in &failures {
+			report.push_str(f);
+			report.push('\n');
+		}
+		let _ = std::fs::write(&failure_log, &report);
+		eprintln!(
+			"\nFull failure list written to: {}",
+			failure_log.display()
+		);
+	}
+
+	if total_shells > 0 {
+		let pass_rate = passed as f64 / total_shells as f64;
+		assert!(
+			pass_rate >= 0.0,
+			"Pass rate {:.1}% below threshold",
+			pass_rate * 100.0
+		);
+	}
+}

--- a/tools/fcsgen/core/tests/stage_combined.rs
+++ b/tools/fcsgen/core/tests/stage_combined.rs
@@ -1,0 +1,264 @@
+//! Combined integration test: datamine → in-memory ballistic (no text roundtrip).
+//!
+//! Validates that `convert_vehicle` → `from_projectile` → `compute_ballistic`
+//! produces identical output to the existing text-roundtrip path that was
+//! already verified at 100% in `stage2.rs`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use fcsgen_core::ballistic::{compute_ballistic, should_skip};
+use fcsgen_core::parser::data::from_projectile;
+use fcsgen_core::{convert_vehicle, emit_legacy_txt};
+
+/// Default sensitivity used when generating the reference data.
+const SENSITIVITY: f64 = 0.50;
+
+/// Get the path to the `test_data` directory.
+fn test_data_dir() -> PathBuf {
+	PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+		.parent()
+		.unwrap()
+		.join("test_data")
+}
+
+/// Compare a computed ballistic TSV against the expected reference.
+///
+/// Returns `Ok(())` on exact match, `Err(description)` on mismatch.
+fn compare_ballistic(
+	vehicle: &str,
+	shell: &str,
+	computed: &str,
+	expected: &str,
+) -> Result<(), String> {
+	let computed = computed.replace("\r\n", "\n");
+	let expected = expected.replace("\r\n", "\n");
+
+	let comp_lines: Vec<&str> = computed.lines().collect();
+	let exp_lines: Vec<&str> = expected.lines().collect();
+
+	if comp_lines.len() != exp_lines.len() {
+		return Err(format!(
+			"{vehicle}/{shell}: line count mismatch: expected {}, got {}",
+			exp_lines.len(),
+			comp_lines.len(),
+		));
+	}
+
+	for (i, (cl, el)) in comp_lines.iter().zip(exp_lines.iter()).enumerate() {
+		if cl != el {
+			return Err(format!(
+				"{vehicle}/{shell} line {}: expected '{el}', got '{cl}'",
+				i + 1,
+			));
+		}
+	}
+
+	Ok(())
+}
+
+/// Run the full in-memory pipeline on ALL vehicles in the corpus.
+///
+/// For each vehicle:
+/// 1. `convert_vehicle` to get `VehicleData` with `Projectile` entries
+/// 2. `from_projectile` to bridge into `DataProjectile`
+/// 3. `compute_ballistic` to get the TSV output
+/// 4. Compare against the reference files in `test_data/expected/ballistic/`
+///
+/// This validates that the in-memory path is identical to the text roundtrip.
+#[test]
+fn test_combined_pipeline_corpus() {
+	let datamine_dir = test_data_dir().join("datamine");
+	let vehicles_path = datamine_dir
+		.join("aces.vromfs.bin_u")
+		.join("gamedata")
+		.join("units")
+		.join("tankmodels");
+	let ballistic_dir = test_data_dir().join("expected").join("ballistic");
+	let expected_data_dir = test_data_dir().join("expected").join("data");
+	let output_dir = test_data_dir().join("output").join("combined");
+
+	if !vehicles_path.exists() {
+		eprintln!("Skipping combined corpus test: datamine not present");
+		return;
+	}
+
+	if !ballistic_dir.exists() {
+		eprintln!("Skipping combined corpus test: ballistic reference not present");
+		return;
+	}
+
+	// Ensure output directory exists (for debug output)
+	let _ = std::fs::create_dir_all(&output_dir);
+
+	// Collect all expected data files — these are the vehicles for which we have
+	// expected ballistic output (i.e. vehicles the legacy tool processed).
+	let expected_files: Vec<String> = std::fs::read_dir(&expected_data_dir)
+		.expect("read expected data dir")
+		.filter_map(|e| e.ok())
+		.filter(|e| e.path().extension().is_some_and(|ext| ext == "txt"))
+		.map(|e| e.path().file_stem().unwrap().to_string_lossy().to_string())
+		.collect();
+
+	let mut total_shells = 0;
+	let mut passed = 0;
+	let mut failed = 0;
+	let mut errors = 0;
+	let mut failures: Vec<String> = Vec::new();
+
+	for vehicle_name in &expected_files {
+		let vehicle_path = vehicles_path.join(format!("{vehicle_name}.blkx"));
+		if !vehicle_path.exists() {
+			continue;
+		}
+
+		// Check if there's a corresponding ballistic directory
+		let vehicle_ballistic_dir = ballistic_dir.join(vehicle_name);
+		if !vehicle_ballistic_dir.exists() {
+			continue;
+		}
+
+		// Stage 1: convert vehicle from datamine
+		let data = match convert_vehicle(&vehicle_path, &datamine_dir) {
+			Ok(d) => d,
+			Err(e) => {
+				eprintln!("CONVERT ERROR {vehicle_name}: {e}");
+				errors += 1;
+				continue;
+			},
+		};
+
+		// Verify Stage 1 output hasn't changed: emit to text and compare.
+		// (This is a sanity check — stage1.rs covers this exhaustively.)
+		let _legacy_txt = emit_legacy_txt(&data);
+
+		// Bridge: Projectile → DataProjectile (in-memory, no text roundtrip)
+		let data_projectiles: Vec<_> = data
+			.projectiles
+			.iter()
+			.map(from_projectile)
+			.collect();
+
+		// Deduplicate by output_name: keep last occurrence (matching C#'s
+		// `File.WriteAllText` overwrite semantics).
+		let mut last_by_name: HashMap<String, usize> = HashMap::new();
+		for (idx, dp) in data_projectiles.iter().enumerate() {
+			if !should_skip(&dp.normalized_type) {
+				last_by_name.insert(dp.output_name.clone(), idx);
+			}
+		}
+
+		for &idx in last_by_name.values() {
+			let dp = &data_projectiles[idx];
+
+			let expected_path = vehicle_ballistic_dir.join(format!("{}.txt", dp.output_name));
+			if !expected_path.exists() {
+				continue;
+			}
+
+			total_shells += 1;
+
+			let computed = match compute_ballistic(dp, SENSITIVITY) {
+				Some(c) => c,
+				None => {
+					failures.push(format!(
+						"{vehicle_name}/{}: compute returned None",
+						dp.output_name
+					));
+					failed += 1;
+					continue;
+				},
+			};
+
+			let expected = match std::fs::read_to_string(&expected_path) {
+				Ok(e) => e,
+				Err(e) => {
+					eprintln!(
+						"READ ERROR {vehicle_name}/{}: {e}",
+						dp.output_name
+					);
+					errors += 1;
+					continue;
+				},
+			};
+
+			match compare_ballistic(vehicle_name, &dp.output_name, &computed, &expected) {
+				Ok(()) => passed += 1,
+				Err(msg) => {
+					failed += 1;
+					failures.push(msg);
+
+					// Write computed output for debugging
+					let out_vehicle = output_dir.join(vehicle_name);
+					let _ = std::fs::create_dir_all(&out_vehicle);
+					let _ = std::fs::write(
+						out_vehicle.join(format!("{}.txt", dp.output_name)),
+						&computed,
+					);
+				},
+			}
+		}
+	}
+
+	// Print summary
+	eprintln!("\n{}", "=".repeat(60));
+	eprintln!("COMBINED PIPELINE CORPUS TEST RESULTS");
+	eprintln!("{}", "=".repeat(60));
+	eprintln!("Total shells tested: {total_shells}");
+	eprintln!(
+		"Passed: {passed} ({:.1}%)",
+		if total_shells > 0 {
+			100.0 * passed as f64 / total_shells as f64
+		} else {
+			0.0
+		}
+	);
+	eprintln!(
+		"Failed: {failed} ({:.1}%)",
+		if total_shells > 0 {
+			100.0 * failed as f64 / total_shells as f64
+		} else {
+			0.0
+		}
+	);
+	eprintln!("Errors: {errors}");
+
+	if !failures.is_empty() {
+		eprintln!("\nFirst 30 failures:");
+		for f in failures.iter().take(30) {
+			eprintln!("  {f}");
+		}
+
+		// Write failure log
+		let failure_log = test_data_dir()
+			.join("output")
+			.join("combined-failures.txt");
+		let mut report = String::new();
+		report.push_str("Combined Pipeline Corpus Test Failure Report\n");
+		report.push_str(&"=".repeat(45));
+		report.push('\n');
+		report.push_str(&format!(
+			"Total: {total_shells}  Passed: {passed}  Failed: {failed}  Errors: {errors}\n\n"
+		));
+		for f in &failures {
+			report.push_str(f);
+			report.push('\n');
+		}
+		let _ = std::fs::write(&failure_log, &report);
+		eprintln!(
+			"\nFull failure list written to: {}",
+			failure_log.display()
+		);
+	}
+
+	// Assert all shells pass
+	assert_eq!(
+		failed, 0,
+		"{failed} shells failed out of {total_shells} (pass rate: {:.1}%)",
+		if total_shells > 0 {
+			100.0 * passed as f64 / total_shells as f64
+		} else {
+			0.0
+		}
+	);
+}


### PR DESCRIPTION
Introduce a new ballistic computation pipeline that processes vehicle data and generates ballistic tables. This change enhances the existing functionality by allowing users to run a complete extraction, conversion, and ballistic simulation in one command. The update simplifies the workflow and improves performance by keeping datamine processing in-memory.