### PR TITLE
fix: restore in-memory pipeline lost during dev merge

### DIFF
--- a/tools/fcsgen/cli/src/extract.rs
+++ b/tools/fcsgen/cli/src/extract.rs
@@ -2,205 +2,303 @@
 //!
 //! Uses the `wt_blk` crate to open `aces.vromfs.bin` and `lang.vromfs.bin`,
 //! unpack the files we need (tank models, weapons, localization CSVs), and
-//! write them to disk in the directory structure that `fcsgen convert` expects.
+//! either return them in memory or write them to disk.
+//!
+//! The default mode (`run_extract_in_memory`) keeps aces files in memory
+//! and only writes lang CSVs to disk, avoiding the 150 MB intermediate dump.
+//! Use `--write-datamine` to also persist the full aces extraction.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::BufRead;
 use std::path::Path;
 
+use fcsgen_core::Datamine;
 use wt_blk::vromf::{BlkOutputFormat, File as VromfFile, VromfUnpacker};
 
 /// Marker filename written to the extraction output directory after a
-/// successful extraction.  Contains the WT version string so we can skip
-/// re-extraction when the archive hasn't changed.
-const VERSION_MARKER: &str = ".fcsgen-version";
+/// successful pipeline run.  Contains the WT version string and sensitivity
+/// so we can skip re-processing when nothing has changed.
+pub const VERSION_MARKER: &str = ".fcsgen-version";
 
-/// Run the full extraction pipeline.
+/// Result of an in-memory extraction.
+pub struct ExtractionResult {
+	/// In-memory aces files: normalized path → JSON string.
+	/// Keys are lowercase with forward slashes, relative to aces.vromfs.bin_u/,
+	/// e.g. `"gamedata/units/tankmodels/us_m1_abrams.blkx"`.
+	pub datamine: Datamine,
+
+	/// Sorted list of vehicle stems (without .blkx extension).
+	pub vehicle_names: Vec<String>,
+
+	/// War Thunder version string extracted from the archive metadata.
+	pub version: String,
+}
+
+/// Extract datamine into memory, only writing lang CSVs to disk.
 ///
-/// Returns `Ok(())` on success or prints diagnostics and calls
-/// `process::exit(1)` on fatal errors (matching the `convert` subcommand
-/// convention).
+/// If `write_datamine` is true, also writes all aces .blkx files to disk
+/// (matching the old behaviour for debugging/testing).
+///
+/// Returns an [`ExtractionResult`] with all aces files in memory.
+pub fn run_extract_in_memory(
+	game_path: &Path,
+	output: &Path,
+	ignore_file: Option<&Path>,
+	write_datamine: bool,
+) -> ExtractionResult {
+	// --- Validate archive paths ---
+	let aces_bin = game_path.join("aces.vromfs.bin");
+	let lang_bin = game_path.join("lang.vromfs.bin");
+
+	if !aces_bin.exists() {
+		eprintln!("Error: aces.vromfs.bin not found at {aces_bin:?}");
+		eprintln!("Make sure the path points to the War Thunder installation directory.");
+		std::process::exit(1);
+	}
+	if !lang_bin.exists() {
+		eprintln!("Error: lang.vromfs.bin not found at {lang_bin:?}");
+		eprintln!("Make sure the path points to the War Thunder installation directory.");
+		std::process::exit(1);
+	}
+
+	// --- Open aces archive ---
+	let aces_file = VromfFile::new(&aces_bin).unwrap_or_else(|e| {
+		eprintln!("Error: failed to read {aces_bin:?}: {e}");
+		std::process::exit(1);
+	});
+	let aces_unpacker = VromfUnpacker::from_file(&aces_file, false).unwrap_or_else(|e| {
+		eprintln!("Error: failed to parse {aces_bin:?}: {e}");
+		std::process::exit(1);
+	});
+
+	// --- Version check ---
+	let version = aces_unpacker.latest_version().unwrap_or_else(|e| {
+		eprintln!("Warning: could not read version from archive: {e}");
+		None
+	});
+
+	let version_str = version.map_or_else(|| "unknown".to_owned(), |v| v.to_string());
+
+	eprintln!("Extracting datamine (version {version_str})...");
+
+	// --- Load ignore list ---
+	let ignore_set = ignore_file.map_or_else(HashSet::new, load_ignore_list);
+
+	// --- Unpack aces archive ---
+	let aces_files = aces_unpacker
+		.unpack_all(Some(BlkOutputFormat::Json), false)
+		.unwrap_or_else(|e| {
+			eprintln!("Error: failed to unpack {aces_bin:?}: {e}");
+			std::process::exit(1);
+		});
+
+	// --- Filter and collect aces files ---
+	let aces_root = output.join("aces.vromfs.bin_u");
+
+	let tankmodels_prefix = Path::new("gamedata/units/tankmodels");
+	let weapons_prefix = Path::new("gamedata/weapons/groundmodels_weapons");
+
+	let mut datamine: Datamine = HashMap::new();
+	let mut vehicle_names: Vec<String> = Vec::new();
+	let mut written_tankmodels: HashSet<String> = HashSet::new();
+	let mut tankmodel_count: u32 = 0;
+	let mut weapon_count: u32 = 0;
+
+	for file in &aces_files {
+		let file_path = file.path();
+
+		// tankmodels: top-level .blk files only (no subdirectories)
+		if let Ok(rel) = file_path.strip_prefix(tankmodels_prefix) {
+			// Top-level only: the relative path should be just a filename
+			if rel.parent().is_some_and(|p| p != Path::new("")) {
+				continue;
+			}
+			let filename = rel.to_string_lossy();
+			if !filename.ends_with(".blk") {
+				continue;
+			}
+
+			// Check ignore list (compare stem, case-insensitive)
+			let stem = filename.strip_suffix(".blk").unwrap_or(&filename);
+			if ignore_set.contains(&stem.to_lowercase()) {
+				continue;
+			}
+
+			// Renamed key: .blk → .blkx
+			let blkx_filename = format!("{filename}x");
+			let key = format!(
+				"{}/{}",
+				tankmodels_prefix.to_string_lossy(),
+				blkx_filename
+			);
+
+			// Store in memory
+			let content = String::from_utf8_lossy(file.buf()).into_owned();
+			datamine.insert(key, content);
+			vehicle_names.push(stem.to_string());
+
+			// Optionally write to disk
+			if write_datamine {
+				let dest = aces_root.join(tankmodels_prefix).join(&blkx_filename);
+				write_file(&dest, file.buf());
+				written_tankmodels.insert(blkx_filename);
+			}
+
+			tankmodel_count += 1;
+			continue;
+		}
+
+		// weapons: all files under groundmodels_weapons
+		if file_path.starts_with(weapons_prefix) {
+			// Normalized key: lowercase path with .blkx extension
+			let key_path = if file_path.extension().is_some_and(|ext| ext == "blk") {
+				file_path.with_extension("blkx")
+			} else {
+				file_path.to_path_buf()
+			};
+			let key = key_path
+				.to_string_lossy()
+				.replace('\\', "/")
+				.to_lowercase();
+
+			// Store in memory
+			let content = String::from_utf8_lossy(file.buf()).into_owned();
+			datamine.insert(key, content);
+
+			// Optionally write to disk
+			if write_datamine {
+				let dest = aces_root.join(&key_path);
+				write_file(&dest, file.buf());
+			}
+
+			weapon_count += 1;
+		}
+	}
+
+	// Delete stale tankmodel files on disk when writing
+	if write_datamine {
+		let tankmodels_dir = aces_root.join(tankmodels_prefix);
+		if tankmodels_dir.is_dir()
+			&& let Ok(entries) = std::fs::read_dir(&tankmodels_dir)
+		{
+			for entry in entries.filter_map(Result::ok) {
+				let name = entry.file_name().to_string_lossy().into_owned();
+				if name.ends_with(".blkx") && !written_tankmodels.contains(&name) {
+					let _ = std::fs::remove_file(entry.path());
+				}
+			}
+		}
+	}
+
+	// Sort vehicle names for deterministic processing order
+	vehicle_names.sort();
+
+	// --- Extract lang archive ---
+	extract_lang(game_path, output);
+
+	eprintln!(
+		"Extracted {tankmodel_count} tankmodels, {weapon_count} weapons (version {version_str})"
+	);
+
+	ExtractionResult {
+		datamine,
+		vehicle_names,
+		version: version_str,
+	}
+}
+
+/// Run the full extraction pipeline, writing all files to disk.
+///
+/// This is the legacy behaviour used by the standalone `extract` subcommand
+/// and `--write-datamine` mode.
 pub fn run_extract(
-    game_path: &Path,
-    output: &Path,
-    ignore_file: Option<&Path>,
-    force: bool,
+	game_path: &Path,
+	output: &Path,
+	ignore_file: Option<&Path>,
+	force: bool,
 ) {
-    // --- Validate archive paths ---
-    let aces_bin = game_path.join("aces.vromfs.bin");
-    let lang_bin = game_path.join("lang.vromfs.bin");
+	// --- Validate archive paths ---
+	let aces_bin = game_path.join("aces.vromfs.bin");
 
-    if !aces_bin.exists() {
-        eprintln!("Error: aces.vromfs.bin not found at {aces_bin:?}");
-        eprintln!("Make sure the path points to the War Thunder installation directory.");
-        std::process::exit(1);
-    }
-    if !lang_bin.exists() {
-        eprintln!("Error: lang.vromfs.bin not found at {lang_bin:?}");
-        eprintln!("Make sure the path points to the War Thunder installation directory.");
-        std::process::exit(1);
-    }
+	if !aces_bin.exists() {
+		eprintln!("Error: aces.vromfs.bin not found at {aces_bin:?}");
+		eprintln!("Make sure the path points to the War Thunder installation directory.");
+		std::process::exit(1);
+	}
 
-    // --- Open aces archive ---
-    let aces_file = VromfFile::new(&aces_bin).unwrap_or_else(|e| {
-        eprintln!("Error: failed to read {aces_bin:?}: {e}");
-        std::process::exit(1);
-    });
-    let aces_unpacker = VromfUnpacker::from_file(&aces_file, false).unwrap_or_else(|e| {
-        eprintln!("Error: failed to parse {aces_bin:?}: {e}");
-        std::process::exit(1);
-    });
+	// --- Version check (skip if up-to-date) ---
+	let aces_file = VromfFile::new(&aces_bin).unwrap_or_else(|e| {
+		eprintln!("Error: failed to read {aces_bin:?}: {e}");
+		std::process::exit(1);
+	});
+	let aces_unpacker = VromfUnpacker::from_file(&aces_file, false).unwrap_or_else(|e| {
+		eprintln!("Error: failed to parse {aces_bin:?}: {e}");
+		std::process::exit(1);
+	});
 
-    // --- Version check ---
-    let version = aces_unpacker.latest_version().unwrap_or_else(|e| {
-        eprintln!("Warning: could not read version from archive: {e}");
-        None
-    });
+	let version = aces_unpacker.latest_version().unwrap_or_else(|e| {
+		eprintln!("Warning: could not read version from archive: {e}");
+		None
+	});
 
-    let version_str = version.map_or_else(|| "unknown".to_owned(), |v| v.to_string());
+	let version_str = version.map_or_else(|| "unknown".to_owned(), |v| v.to_string());
 
-    let marker_path = output.join(VERSION_MARKER);
-    if !force {
-        if let Ok(cached) = std::fs::read_to_string(&marker_path) {
-            if cached.trim() == version_str {
-                eprintln!("Already up-to-date (version {version_str})");
-                return;
-            }
-        }
-    }
+	let marker_path = output.join(VERSION_MARKER);
+	if !force {
+		if let Ok(cached) = std::fs::read_to_string(&marker_path) {
+			if cached.trim() == version_str {
+				eprintln!("Already up-to-date (version {version_str})");
+				return;
+			}
+		}
+	}
 
-    eprintln!("Extracting datamine (version {version_str})...");
+	// Full extraction with disk writes
+	run_extract_in_memory(game_path, output, ignore_file, true);
+}
 
-    // --- Load ignore list ---
-    let ignore_set = ignore_file.map_or_else(HashSet::new, |path| load_ignore_list(path));
+/// Extract lang CSVs from lang.vromfs.bin.
+fn extract_lang(game_path: &Path, output: &Path) {
+	let lang_bin = game_path.join("lang.vromfs.bin");
 
-    // --- Unpack aces archive ---
-    let aces_files = aces_unpacker
-        .unpack_all(Some(BlkOutputFormat::Json), false)
-        .unwrap_or_else(|e| {
-            eprintln!("Error: failed to unpack {aces_bin:?}: {e}");
-            std::process::exit(1);
-        });
+	let lang_file = VromfFile::new(&lang_bin).unwrap_or_else(|e| {
+		eprintln!("Error: failed to read {lang_bin:?}: {e}");
+		std::process::exit(1);
+	});
+	let lang_unpacker = VromfUnpacker::from_file(&lang_file, false).unwrap_or_else(|e| {
+		eprintln!("Error: failed to parse {lang_bin:?}: {e}");
+		std::process::exit(1);
+	});
 
-    // --- Filter and write aces files ---
-    let aces_root = output.join("aces.vromfs.bin_u");
+	// CSVs are plain text, no BLK decoding needed
+	let lang_files = lang_unpacker
+		.unpack_all(None, false)
+		.unwrap_or_else(|e| {
+			eprintln!("Error: failed to unpack {lang_bin:?}: {e}");
+			std::process::exit(1);
+		});
 
-    let tankmodels_prefix = Path::new("gamedata/units/tankmodels");
-    let weapons_prefix = Path::new("gamedata/weapons/groundmodels_weapons");
+	let mut lang_count: u32 = 0;
+	let lang_targets: [&str; 2] = ["lang/units.csv", "lang/units_weaponry.csv"];
+	let lang_root = output.join("lang.vromfs.bin_u");
 
-    let mut tankmodel_count: u32 = 0;
-    let mut weapon_count: u32 = 0;
-    let mut written_tankmodels: HashSet<String> = HashSet::new();
+	for file in &lang_files {
+		let file_path = file.path();
+		let path_str = file_path.to_string_lossy();
 
-    for file in &aces_files {
-        let file_path = file.path();
+		// Normalize path separators for comparison
+		let normalized: String = path_str.replace('\\', "/");
 
-        // tankmodels: top-level .blk files only (no subdirectories)
-        if let Ok(rel) = file_path.strip_prefix(tankmodels_prefix) {
-            // Top-level only: the relative path should be just a filename (no parent components)
-            if rel.parent().is_some_and(|p| p != Path::new("")) {
-                continue;
-            }
-            let filename = rel.to_string_lossy();
-            if !filename.ends_with(".blk") {
-                continue;
-            }
+		for target in &lang_targets {
+			if normalized == *target {
+				let dest = lang_root.join(target);
+				write_file(&dest, file.buf());
+				lang_count += 1;
+			}
+		}
+	}
 
-            // Rename .blk → .blkx (matching the convention expected by `fcsgen convert`)
-            let blkx_filename = format!("{filename}x");
-
-            // Check ignore list (ignore.txt uses .blkx names, case-insensitive)
-            let lower = blkx_filename.to_lowercase();
-            if ignore_set.contains(&lower)
-            {
-                continue;
-            }
-
-            // Write with .blkx extension
-            let dest = aces_root.join(tankmodels_prefix).join(&blkx_filename);
-            write_file(&dest, file.buf());
-            written_tankmodels.insert(blkx_filename);
-            tankmodel_count += 1;
-            continue;
-        }
-
-        // weapons: all files under groundmodels_weapons
-        if file_path.starts_with(weapons_prefix) {
-            // Rename .blk → .blkx for weapons too
-            let dest_path = if file_path.extension().is_some_and(|ext| ext == "blk") {
-                aces_root.join(file_path.with_extension("blkx"))
-            } else {
-                aces_root.join(file_path)
-            };
-            write_file(&dest_path, file.buf());
-            weapon_count += 1;
-        }
-    }
-
-    // --- Delete stale tankmodel files ---
-    let tankmodels_dir = aces_root.join(tankmodels_prefix);
-    if tankmodels_dir.is_dir() {
-        if let Ok(entries) = std::fs::read_dir(&tankmodels_dir) {
-            for entry in entries.filter_map(Result::ok) {
-                let name = entry.file_name().to_string_lossy().into_owned();
-                if name.ends_with(".blkx") && !written_tankmodels.contains(&name) {
-                    let _ = std::fs::remove_file(entry.path());
-                }
-            }
-        }
-    }
-
-    // --- Extract lang archive ---
-    let lang_file = VromfFile::new(&lang_bin).unwrap_or_else(|e| {
-        eprintln!("Error: failed to read {lang_bin:?}: {e}");
-        std::process::exit(1);
-    });
-    let lang_unpacker = VromfUnpacker::from_file(&lang_file, false).unwrap_or_else(|e| {
-        eprintln!("Error: failed to parse {lang_bin:?}: {e}");
-        std::process::exit(1);
-    });
-
-    // CSVs are plain text, no BLK decoding needed
-    let lang_files = lang_unpacker
-        .unpack_all(None, false)
-        .unwrap_or_else(|e| {
-            eprintln!("Error: failed to unpack {lang_bin:?}: {e}");
-            std::process::exit(1);
-        });
-
-    let mut lang_count: u32 = 0;
-    let lang_targets: [&str; 2] = ["lang/units.csv", "lang/units_weaponry.csv"];
-    let lang_root = output.join("lang.vromfs.bin_u");
-
-    for file in &lang_files {
-        let file_path = file.path();
-        let path_str = file_path.to_string_lossy();
-
-        // Normalize path separators for comparison
-        let normalized: String = path_str.replace('\\', "/");
-
-        for target in &lang_targets {
-            if normalized == *target {
-                // Write mirroring archive structure: output/lang.vromfs.bin_u/lang/<file>
-                let dest = lang_root.join(target);
-                write_file(&dest, file.buf());
-                lang_count += 1;
-            }
-        }
-    }
-
-    // --- Write version marker ---
-    if let Err(e) = std::fs::create_dir_all(output) {
-        eprintln!("Error: cannot create output directory {output:?}: {e}");
-        std::process::exit(1);
-    }
-    if let Err(e) = std::fs::write(&marker_path, &version_str) {
-        eprintln!("Warning: failed to write version marker: {e}");
-    }
-
-    eprintln!(
-        "Extracted {tankmodel_count} tankmodels, {weapon_count} weapons, {lang_count} lang files (version {version_str})"
-    );
+	eprintln!("Extracted {lang_count} lang files");
 }
 
 /// Write `data` to `path`, creating parent directories as needed.
@@ -219,8 +317,8 @@ fn write_file(path: &Path, data: &[u8]) {
 
 /// Load a vehicle ignore list from a file.
 ///
-/// Each line is a filename (optionally quoted, with `#` comment lines).
-/// Returns a set of filenames (with quotes stripped).
+/// Each line is a vehicle ID (optionally quoted, with `#` comment lines).
+/// Returns a set of vehicle IDs (lowercased, quotes and `.blkx` extension stripped).
 fn load_ignore_list(path: &Path) -> HashSet<String> {
     let file = match std::fs::File::open(path) {
         Ok(f) => f,
@@ -237,13 +335,15 @@ fn load_ignore_list(path: &Path) -> HashSet<String> {
         .map(|line| line.trim().to_owned())
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .map(|line| {
-            // Strip surrounding quotes
+            // Strip surrounding quotes (legacy format compat)
             if line.starts_with('"') && line.ends_with('"') && line.len() >= 2 {
                 line[1..line.len() - 1].to_owned()
             } else {
                 line
             }
         })
+        // Strip .blkx extension if present (legacy format compat)
+        .map(|s| s.strip_suffix(".blkx").unwrap_or(&s).to_owned())
         // Lowercase for case-insensitive matching (archive names are lowercase)
         .map(|s| s.to_lowercase())
         .collect()

--- a/tools/fcsgen/cli/src/main.rs
+++ b/tools/fcsgen/cli/src/main.rs
@@ -58,6 +58,10 @@ enum Commands {
 		/// Skip ballistic computation (only extract + convert)
 		#[arg(long, default_value_t = false)]
 		skip_ballistic: bool,
+
+		/// Write full datamine .blkx files to disk (for debugging/testing)
+		#[arg(long, default_value_t = false)]
+		write_datamine: bool,
 	},
 
 	/// Convert datamine to Data/*.txt format (legacy, prefer `run`)
@@ -127,6 +131,7 @@ fn main() {
 			jobs,
 			skip_extract,
 			skip_ballistic,
+			write_datamine,
 		} => {
 			run::run_pipeline(&run::PipelineConfig {
 				game_path: &game_path,
@@ -137,6 +142,7 @@ fn main() {
 				jobs,
 				skip_extract,
 				skip_ballistic,
+				write_datamine,
 			});
 		},
 		Commands::Convert {

--- a/tools/fcsgen/cli/src/run.rs
+++ b/tools/fcsgen/cli/src/run.rs
@@ -3,21 +3,23 @@
 //! Replaces the old three-step CLI workflow (`extract` + `convert` + `ballistic`)
 //! with a single command that pipes data in-memory where possible.
 //!
+//! By default, datamine files (.blkx) are kept in memory and never written to
+//! disk — only `Data/*.txt`, `Ballistic/{vehicle}/{shell}.txt`, and lang CSVs
+//! are persisted.  Use `--write-datamine` to also dump the full extraction.
+//!
 //! Vehicles are processed in parallel via [`rayon`], with a shared
 //! [`BallisticCache`] (backed by `DashMap`) for cross-vehicle shell
 //! deduplication.
-//!
-//! `Data/*.txt` files are still written (the C# sight generator reads them).
-//! `Ballistic/{vehicle}/{shell}.txt` files are still written.
 
 use std::collections::HashMap;
 use std::path::Path;
 
 use rayon::prelude::*;
+use wt_blk::vromf::{File as VromfFile, VromfUnpacker};
 
 use fcsgen_core::ballistic::{BallisticCache, compute_ballistic_cached, should_skip};
 use fcsgen_core::parser::data::from_projectile;
-use fcsgen_core::{convert_vehicle, emit_legacy_txt};
+use fcsgen_core::{convert_vehicle, convert_vehicle_in_memory, emit_legacy_txt};
 
 use crate::extract;
 
@@ -31,6 +33,7 @@ pub struct PipelineConfig<'a> {
 	pub jobs: usize,
 	pub skip_extract: bool,
 	pub skip_ballistic: bool,
+	pub write_datamine: bool,
 }
 
 /// Per-vehicle statistics returned from each parallel work unit.
@@ -61,6 +64,81 @@ impl VehicleStats {
 	}
 }
 
+/// Check whether the pipeline output is already up-to-date.
+///
+/// Reads the version marker from `datamine_dir` (two-line format:
+/// `version\nsensitivity`) and compares against the current archive version
+/// and requested sensitivity.  Also verifies that `data_dir` contains at
+/// least one `.txt` file and `ballistic_dir` exists.
+///
+/// Returns the cached version string if up-to-date, `None` otherwise.
+fn check_up_to_date(
+	game_path: &Path,
+	datamine_dir: &Path,
+	data_dir: &Path,
+	ballistic_dir: &Path,
+	sensitivity: f64,
+	skip_ballistic: bool,
+) -> Option<String> {
+	// Read marker file (two-line format: "version\nsensitivity")
+	let marker_path = datamine_dir.join(extract::VERSION_MARKER);
+	let marker_content = std::fs::read_to_string(&marker_path).ok()?;
+	let mut lines = marker_content.lines();
+	let cached_version = lines.next()?.trim();
+	let cached_sensitivity: f64 = lines.next()?.trim().parse().ok()?;
+
+	// Compare sensitivity
+	if (cached_sensitivity - sensitivity).abs() > f64::EPSILON {
+		return None;
+	}
+
+	// Verify Data/ has at least one .txt file
+	let has_data_files = std::fs::read_dir(data_dir)
+		.ok()?
+		.filter_map(Result::ok)
+		.any(|e| {
+			e.path()
+				.extension()
+				.is_some_and(|ext| ext == "txt")
+		});
+	if !has_data_files {
+		return None;
+	}
+
+	// Verify Ballistic/ exists (unless ballistic is skipped)
+	if !skip_ballistic && !ballistic_dir.is_dir() {
+		return None;
+	}
+
+	// Read archive version without unpacking
+	let aces_bin = game_path.join("aces.vromfs.bin");
+	let aces_file = VromfFile::new(&aces_bin).ok()?;
+	let aces_unpacker = VromfUnpacker::from_file(&aces_file, true).ok()?;
+	let version = aces_unpacker.latest_version().ok()??;
+	let version_str = version.to_string();
+
+	if cached_version == version_str {
+		Some(version_str)
+	} else {
+		None
+	}
+}
+
+/// Write the version+sensitivity marker after a successful pipeline run.
+fn write_marker(datamine_dir: &Path, version: &str, sensitivity: f64) {
+	if let Err(e) = std::fs::create_dir_all(datamine_dir) {
+		eprintln!("Warning: cannot create Datamine dir for marker: {e}");
+		return;
+	}
+	let marker_path = datamine_dir.join(extract::VERSION_MARKER);
+	let content = format!(
+		"{version}\n{sensitivity}",
+	);
+	if let Err(e) = std::fs::write(&marker_path, content) {
+		eprintln!("Warning: failed to write version marker: {e}");
+	}
+}
+
 /// Run the full pipeline: extract → convert → ballistic.
 #[allow(clippy::too_many_lines)]
 pub fn run_pipeline(cfg: &PipelineConfig<'_>) {
@@ -68,15 +146,197 @@ pub fn run_pipeline(cfg: &PipelineConfig<'_>) {
 	let data_dir = cfg.output.join("Data");
 	let ballistic_dir = cfg.output.join("Ballistic");
 
-	// ── Step 1: Extract ────────────────────────────────────────────────
-	if cfg.skip_extract {
-		eprintln!("Step 1/3: Skipping extraction (--skip-extract)");
-	} else {
-		eprintln!("Step 1/3: Extracting datamine...");
-		extract::run_extract(cfg.game_path, &datamine_dir, cfg.ignore_file, false);
+	// Create output directories
+	for dir in [&data_dir, &ballistic_dir] {
+		if let Err(e) = std::fs::create_dir_all(dir) {
+			eprintln!("Error: cannot create directory {}: {e}", dir.display());
+			std::process::exit(1);
+		}
 	}
 
-	// ── Step 2+3: Convert + Ballistic (in-memory pipeline) ─────────────
+	// ── Freshness check: skip if version+sensitivity unchanged ─────────
+	if !cfg.skip_extract {
+		if let Some(ver) = check_up_to_date(
+			cfg.game_path,
+			&datamine_dir,
+			&data_dir,
+			&ballistic_dir,
+			cfg.sensitivity,
+			cfg.skip_ballistic,
+		) {
+			eprintln!(
+				"Already up-to-date (version {ver}, sensitivity {})",
+				cfg.sensitivity,
+			);
+			return;
+		}
+	}
+
+	// Configure rayon thread pool
+	let thread_count = if cfg.jobs > 0 {
+		cfg.jobs
+	} else {
+		std::thread::available_parallelism()
+			.map(std::num::NonZero::get)
+			.unwrap_or(1)
+	};
+
+	if cfg.jobs > 0 {
+		rayon::ThreadPoolBuilder::new()
+			.num_threads(thread_count)
+			.build_global()
+			.ok(); // Ignore if already initialized (e.g. in tests)
+	}
+
+	// Cross-vehicle ballistic cache
+	let ballistic_cache: BallisticCache = BallisticCache::new();
+
+	let sensitivity = cfg.sensitivity;
+	let skip_ballistic = cfg.skip_ballistic;
+
+	// ── Branch: in-memory vs disk-based extraction ─────────────────────
+	if cfg.skip_extract {
+		// Disk-based path: read .blkx files from a previous extraction
+		eprintln!("Step 1/3: Skipping extraction (--skip-extract)");
+		run_pipeline_from_disk(
+			cfg,
+			&datamine_dir,
+			&data_dir,
+			&ballistic_dir,
+			&ballistic_cache,
+			sensitivity,
+			skip_ballistic,
+			thread_count,
+		);
+	} else {
+		// In-memory path: extract → convert → ballistic without writing .blkx
+		eprintln!("Step 1/3: Extracting datamine...");
+		let extraction = extract::run_extract_in_memory(
+			cfg.game_path,
+			&datamine_dir,
+			cfg.ignore_file,
+			cfg.write_datamine,
+		);
+		run_pipeline_in_memory(
+			cfg,
+			&extraction,
+			&data_dir,
+			&ballistic_dir,
+			&ballistic_cache,
+			sensitivity,
+			skip_ballistic,
+			thread_count,
+		);
+
+		// Write version+sensitivity marker on success
+		write_marker(&datamine_dir, &extraction.version, sensitivity);
+	}
+}
+
+/// Pipeline branch: process vehicles from in-memory datamine.
+fn run_pipeline_in_memory(
+	cfg: &PipelineConfig<'_>,
+	extraction: &extract::ExtractionResult,
+	data_dir: &Path,
+	ballistic_dir: &Path,
+	ballistic_cache: &BallisticCache,
+	sensitivity: f64,
+	skip_ballistic: bool,
+	thread_count: usize,
+) {
+	// Apply vehicle filter
+	let vehicle_names: Vec<&String> = extraction
+		.vehicle_names
+		.iter()
+		.filter(|name| {
+			if let Some(filter) = cfg.filter {
+				filter.iter().any(|f| f == *name)
+			} else {
+				true
+			}
+		})
+		.collect();
+
+	let total = vehicle_names.len();
+	let tankmodels_prefix = "gamedata/units/tankmodels";
+
+	eprintln!(
+		"Step 2/3: Converting {total} vehicles (+ ballistic, sensitivity={}, jobs={thread_count})",
+		cfg.sensitivity,
+	);
+	eprintln!("  Data:      {}", data_dir.display());
+	if !skip_ballistic {
+		eprintln!("  Ballistic: {}", ballistic_dir.display());
+	}
+	eprintln!();
+
+	let stats = vehicle_names
+		.par_iter()
+		.map(|name| {
+			let mut vs = VehicleStats::default();
+
+			// Look up vehicle content from in-memory datamine
+			let key = format!("{tankmodels_prefix}/{name}.blkx");
+			let vehicle_content = match extraction.datamine.get(&key) {
+				Some(content) => content,
+				None => {
+					eprintln!("CONVERT ERROR {name}: not found in datamine");
+					vs.convert_failed += 1;
+					return vs;
+				},
+			};
+
+			// Convert vehicle from in-memory data
+			let data = match convert_vehicle_in_memory(name, vehicle_content, &extraction.datamine)
+			{
+				Ok(d) => d,
+				Err(e) => {
+					eprintln!("CONVERT ERROR {name}: {e}");
+					vs.convert_failed += 1;
+					return vs;
+				},
+			};
+
+			if !data.is_armed() {
+				vs.skipped += 1;
+				return vs;
+			}
+
+			// Write Data/{vehicle}.txt (needed by C# sight generator)
+			let txt = emit_legacy_txt(&data);
+			let data_path = data_dir.join(format!("{name}.txt"));
+			if let Err(e) = std::fs::write(&data_path, &txt) {
+				eprintln!("WRITE ERROR {name}: {e}");
+				vs.convert_failed += 1;
+				return vs;
+			}
+
+			vs.converted += 1;
+
+			// Ballistic computation
+			if skip_ballistic {
+				return vs;
+			}
+
+			process_ballistic(&data, name, ballistic_dir, sensitivity, ballistic_cache, &mut vs);
+			vs
+		})
+		.reduce(VehicleStats::default, VehicleStats::merge);
+
+	print_stats(&stats, skip_ballistic);
+}
+
+/// Pipeline branch: process vehicles from disk-based datamine.
+fn run_pipeline_from_disk(
+	cfg: &PipelineConfig<'_>,
+	datamine_dir: &Path,
+	data_dir: &Path,
+	ballistic_dir: &Path,
+	ballistic_cache: &BallisticCache,
+	sensitivity: f64,
+	skip_ballistic: bool,
+	thread_count: usize,
+) {
 	let aces_root = datamine_dir.join("aces.vromfs.bin_u");
 	let tankmodels = aces_root.join("gamedata").join("units").join("tankmodels");
 
@@ -87,14 +347,6 @@ pub fn run_pipeline(cfg: &PipelineConfig<'_>) {
 		);
 		eprintln!("Run without --skip-extract to populate the datamine first.");
 		std::process::exit(1);
-	}
-
-	// Create output directories
-	for dir in [&data_dir, &ballistic_dir] {
-		if let Err(e) = std::fs::create_dir_all(dir) {
-			eprintln!("Error: cannot create directory {}: {e}", dir.display());
-			std::process::exit(1);
-		}
 	}
 
 	// Collect vehicle files
@@ -113,43 +365,17 @@ pub fn run_pipeline(cfg: &PipelineConfig<'_>) {
 		.collect();
 
 	vehicles.sort_by_key(std::fs::DirEntry::file_name);
-
 	let total = vehicles.len();
-
-	// Cross-vehicle ballistic cache: shells with identical physics share
-	// the same trajectory output regardless of which vehicle fires them.
-	// DashMap provides lock-free concurrent reads with fine-grained sharded
-	// locking on writes — ideal for the 80% cache-hit rate we see.
-	let ballistic_cache: BallisticCache = BallisticCache::new();
-
-	// Configure rayon thread pool
-	let thread_count = if cfg.jobs > 0 {
-		cfg.jobs
-	} else {
-		std::thread::available_parallelism()
-			.map(std::num::NonZero::get)
-			.unwrap_or(1)
-	};
-
-	if cfg.jobs > 0 {
-		rayon::ThreadPoolBuilder::new()
-			.num_threads(thread_count)
-			.build_global()
-			.ok(); // Ignore if already initialized (e.g. in tests)
-	}
 
 	eprintln!(
 		"Step 2/3: Converting {total} vehicles (+ ballistic, sensitivity={}, jobs={thread_count})",
 		cfg.sensitivity,
 	);
 	eprintln!("  Data:      {}", data_dir.display());
-	if !cfg.skip_ballistic {
+	if !skip_ballistic {
 		eprintln!("  Ballistic: {}", ballistic_dir.display());
 	}
 	eprintln!();
-
-	let sensitivity = cfg.sensitivity;
-	let skip_ballistic = cfg.skip_ballistic;
 
 	let stats = vehicles
 		.par_iter()
@@ -158,8 +384,8 @@ pub fn run_pipeline(cfg: &PipelineConfig<'_>) {
 			let path = entry.path();
 			let name = path.file_stem().unwrap().to_string_lossy().to_string();
 
-			// Convert vehicle from datamine
-			let data = match convert_vehicle(&path, &datamine_dir) {
+			// Convert vehicle from disk
+			let data = match convert_vehicle(&path, datamine_dir) {
 				Ok(d) => d,
 				Err(e) => {
 					eprintln!("CONVERT ERROR {name}: {e}");
@@ -173,7 +399,7 @@ pub fn run_pipeline(cfg: &PipelineConfig<'_>) {
 				return vs;
 			}
 
-			// Write Data/{vehicle}.txt (still needed by C# sight generator)
+			// Write Data/{vehicle}.txt
 			let txt = emit_legacy_txt(&data);
 			let data_path = data_dir.join(format!("{name}.txt"));
 			if let Err(e) = std::fs::write(&data_path, &txt) {
@@ -184,78 +410,85 @@ pub fn run_pipeline(cfg: &PipelineConfig<'_>) {
 
 			vs.converted += 1;
 
-			// ── In-memory ballistic computation ────────────────────────
 			if skip_ballistic {
 				return vs;
 			}
 
-			// Bridge Projectile → DataProjectile
-			let data_projectiles: Vec<_> = data
-				.projectiles
-				.iter()
-				.map(from_projectile)
-				.collect();
-
-			// Deduplicate by output_name: keep last occurrence (matching
-			// C#'s `File.WriteAllText` overwrite semantics).
-			let mut last_by_name: HashMap<String, usize> = HashMap::new();
-			for (idx, dp) in data_projectiles.iter().enumerate() {
-				if !should_skip(&dp.normalized_type) {
-					last_by_name.insert(dp.output_name.clone(), idx);
-				}
-			}
-
-			let vehicle_dir = ballistic_dir.join(&name);
-			let mut dir_created = false;
-
-			for &idx in last_by_name.values() {
-				let dp = &data_projectiles[idx];
-
-				let (result, hit) =
-					compute_ballistic_cached(dp, sensitivity, &ballistic_cache);
-				if hit {
-					vs.cache_hits += 1;
-				} else {
-					vs.cache_misses += 1;
-				}
-
-				if let Some(content) = result {
-					if content.is_empty() {
-						continue;
-					}
-
-					// Ensure vehicle subdirectory exists
-					if !dir_created {
-						if let Err(e) = std::fs::create_dir_all(&vehicle_dir) {
-							eprintln!("DIR ERROR {name}: {e}");
-							vs.ballistic_errors += 1;
-							break;
-						}
-						dir_created = true;
-					}
-
-					let filename = format!("{}.txt", dp.output_name);
-					let file_path = vehicle_dir.join(&filename);
-
-					if let Err(e) = std::fs::write(&file_path, &content) {
-						eprintln!("WRITE ERROR {name}/{filename}: {e}");
-						vs.ballistic_errors += 1;
-					} else {
-						vs.shells_written += 1;
-					}
-				}
-			}
-
+			process_ballistic(&data, &name, ballistic_dir, sensitivity, ballistic_cache, &mut vs);
 			vs
 		})
 		.reduce(VehicleStats::default, VehicleStats::merge);
 
+	print_stats(&stats, skip_ballistic);
+}
+
+/// Compute and write ballistic tables for a single vehicle's projectiles.
+fn process_ballistic(
+	data: &fcsgen_core::VehicleData,
+	name: &str,
+	ballistic_dir: &Path,
+	sensitivity: f64,
+	ballistic_cache: &BallisticCache,
+	vs: &mut VehicleStats,
+) {
+	let data_projectiles: Vec<_> = data.projectiles.iter().map(from_projectile).collect();
+
+	// Deduplicate by output_name
+	let mut last_by_name: HashMap<String, usize> = HashMap::new();
+	for (idx, dp) in data_projectiles.iter().enumerate() {
+		if !should_skip(&dp.normalized_type) {
+			last_by_name.insert(dp.output_name.clone(), idx);
+		}
+	}
+
+	let vehicle_dir = ballistic_dir.join(name);
+	let mut dir_created = false;
+
+	for &idx in last_by_name.values() {
+		let dp = &data_projectiles[idx];
+
+		let (result, hit) = compute_ballistic_cached(dp, sensitivity, ballistic_cache);
+		if hit {
+			vs.cache_hits += 1;
+		} else {
+			vs.cache_misses += 1;
+		}
+
+		if let Some(content) = result {
+			if content.is_empty() {
+				continue;
+			}
+
+			if !dir_created {
+				if let Err(e) = std::fs::create_dir_all(&vehicle_dir) {
+					eprintln!("DIR ERROR {name}: {e}");
+					vs.ballistic_errors += 1;
+					break;
+				}
+				dir_created = true;
+			}
+
+			let filename = format!("{}.txt", dp.output_name);
+			let file_path = vehicle_dir.join(&filename);
+
+			if let Err(e) = std::fs::write(&file_path, &content) {
+				eprintln!("WRITE ERROR {name}/{filename}: {e}");
+				vs.ballistic_errors += 1;
+			} else {
+				vs.shells_written += 1;
+			}
+		}
+	}
+}
+
+/// Print final pipeline statistics.
+fn print_stats(stats: &VehicleStats, skip_ballistic: bool) {
 	eprintln!();
 	eprintln!(
 		"Done: {} converted, {} skipped (unarmed), {} convert errors",
 		stats.converted, stats.skipped, stats.convert_failed,
 	);
-	if !cfg.skip_ballistic {
+	if !skip_ballistic {
 		let total_lookups = stats.cache_hits + stats.cache_misses;
 		eprintln!(
 			"      {} ballistic tables written, {} ballistic errors",
@@ -265,7 +498,11 @@ pub fn run_pipeline(cfg: &PipelineConfig<'_>) {
 			"      Cache: {} unique / {total_lookups} total ({} hits, {:.0}% reuse)",
 			stats.cache_misses,
 			stats.cache_hits,
-			if total_lookups > 0 { 100.0 * stats.cache_hits as f64 / total_lookups as f64 } else { 0.0 },
+			if total_lookups > 0 {
+				100.0 * stats.cache_hits as f64 / total_lookups as f64
+			} else {
+				0.0
+			},
 		);
 	}
 }

--- a/tools/fcsgen/core/src/lib.rs
+++ b/tools/fcsgen/core/src/lib.rs
@@ -20,9 +20,15 @@ pub use model::{Projectile, VehicleData};
 pub use parser::data::{from_projectile, parse_data_file, parse_data_text};
 pub use parser::{parse_vehicle, parse_weapon_module};
 
+use std::collections::HashMap;
 use std::path::Path;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// In-memory datamine: maps normalized paths (relative to aces.vromfs.bin_u/)
+/// to file contents. Keys are lowercase with forward slashes, e.g.
+/// `"gamedata/units/tankmodels/us_m1_abrams.blkx"`.
+pub type Datamine = HashMap<String, String>;
 
 /// Convert a vehicle from datamine to legacy Data format.
 ///
@@ -42,24 +48,66 @@ pub fn convert_vehicle(vehicle_path: &Path, datamine_root: &Path) -> Result<Vehi
 		.and_then(|s| s.to_str())
 		.unwrap_or("unknown");
 
-	let mut data = parse_vehicle(&vehicle_json, vehicle_id)?;
-
-	// Parse weapon module and collect projectiles (pass vehicle JSON for belt filtering)
-	if let Some(ref weapon_path) = data.weapon_path {
+	convert_vehicle_impl(vehicle_id, &vehicle_json, &|weapon_path| {
 		let full_path = resolve_weapon_path(datamine_root, weapon_path);
 		if full_path.exists() {
-			let weapon_json = read_json_file(&full_path)?;
-			let projectiles = parse_weapon_module(&weapon_json, Some(&vehicle_json))?;
-			data.projectiles.extend(projectiles);
+			std::fs::read_to_string(&full_path).ok()
+		} else {
+			None
 		}
+	})
+}
+
+/// Convert a vehicle from in-memory datamine data.
+///
+/// Same as [`convert_vehicle`] but reads all related files from an in-memory
+/// [`Datamine`] map instead of the filesystem.
+///
+/// # Arguments
+/// * `vehicle_id` - Vehicle identifier (stem name, e.g. "us_m1_abrams")
+/// * `vehicle_content` - JSON string of the vehicle .blkx file
+/// * `datamine` - In-memory map of all extracted datamine files
+pub fn convert_vehicle_in_memory(
+	vehicle_id: &str,
+	vehicle_content: &str,
+	datamine: &Datamine,
+) -> Result<VehicleData> {
+	let vehicle_json: serde_json::Value = serde_json::from_str(vehicle_content)
+		.map_err(|e| ParseError::json(format!("<memory>/{vehicle_id}.blkx"), e))?;
+
+	convert_vehicle_impl(vehicle_id, &vehicle_json, &|weapon_path| {
+		let key = weapon_path.replace('\\', "/").to_lowercase();
+		datamine.get(&key).cloned()
+	})
+}
+
+/// Shared implementation for vehicle conversion.
+///
+/// `resolve_related` looks up a weapon/rocket .blkx path and returns its JSON
+/// content string, or `None` if the file is not found.
+fn convert_vehicle_impl(
+	vehicle_id: &str,
+	vehicle_json: &serde_json::Value,
+	resolve_related: &dyn Fn(&str) -> Option<String>,
+) -> Result<VehicleData> {
+	let mut data = parse_vehicle(vehicle_json, vehicle_id)?;
+
+	// Parse weapon module and collect projectiles
+	if let Some(ref weapon_path) = data.weapon_path
+		&& let Some(content) = resolve_related(weapon_path)
+	{
+		let weapon_json: serde_json::Value = serde_json::from_str(&content)
+			.map_err(|e| ParseError::json(weapon_path.as_str(), e))?;
+		let projectiles = parse_weapon_module(&weapon_json, Some(vehicle_json))?;
+		data.projectiles.extend(projectiles);
 	}
 
-	// Parse rocket modules and collect projectiles (pass vehicle JSON for belt filtering)
+	// Parse rocket modules and collect projectiles
 	for rocket_path in data.rocket_paths.clone() {
-		let full_path = resolve_weapon_path(datamine_root, &rocket_path);
-		if full_path.exists() {
-			let rocket_json = read_json_file(&full_path)?;
-			let projectiles = parse_weapon_module(&rocket_json, Some(&vehicle_json))?;
+		if let Some(content) = resolve_related(&rocket_path) {
+			let rocket_json: serde_json::Value = serde_json::from_str(&content)
+				.map_err(|e| ParseError::json(rocket_path.as_str(), e))?;
+			let projectiles = parse_weapon_module(&rocket_json, Some(vehicle_json))?;
 			data.projectiles.extend(projectiles);
 		}
 	}


### PR DESCRIPTION
## Summary

Restores functionality that was lost when merging dev into main (the Codex-assisted merge flattened the in-memory pipeline back to disk-only).

## Changes

**`tools/fcsgen/cli/src/extract.rs`**
- Restore `run_extract_in_memory()` and `ExtractionResult` struct
- Make `VERSION_MARKER` public

**`tools/fcsgen/cli/src/run.rs`**
- Restore `check_up_to_date()` freshness check and `write_marker()`
- Restore `run_pipeline_in_memory()` branch
- Restore `write_datamine` config field

**`tools/fcsgen/cli/src/main.rs`**
- Restore `--write-datamine` CLI flag

**`tools/fcsgen/core/src/lib.rs`**
- Restore `Datamine` type alias (`HashMap<String, String>`)
- Restore `convert_vehicle_in_memory()` function
- Restore shared `convert_vehicle_impl()` helper

## Testing

All 23 tests pass (20 unit + 3 integration corpus tests).