### PR TITLE
refactor: rename default sight output folder from UserSights to Output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -445,8 +445,8 @@ FodyWeavers.xsd
 /tools/fcsgen/target/
 
 
-UserSights/
-!UserSights/.gitkeep
+Output/
+!Output/.gitkeep
 Datamine/aces.vromfs.bin_u/gamedata/units/tankmodels/*
 !Datamine/aces.vromfs.bin_u/gamedata/units/tankmodels/.gitkeep
 Datamine/aces.vromfs.bin_u/gamedata/weapons/groundmodels_weapons/*

--- a/src/Form1.Designer.cs
+++ b/src/Form1.Designer.cs
@@ -177,7 +177,7 @@ namespace FCS
             this.textBox4.Name = "textBox4";
             this.textBox4.Size = new System.Drawing.Size(241, 20);
             this.textBox4.TabIndex = 3;
-            this.textBox4.Text = "UserSights";
+            this.textBox4.Text = "Output";
             this.textBox4.Click += new System.EventHandler(this.TextBox4_Click);
             //
             // progressBar1


### PR DESCRIPTION
## Summary

Rename the default sight output folder from `UserSights` to `Output` to avoid confusion with the game's own `UserSights` folder. Users were getting confused having two different folders named `UserSights` involved in the workflow.

## Changes

- **`src/Form1.Designer.cs`** — textBox4 default text changed from `"UserSights"` to `"Output"`
- **`.gitignore`** — updated ignore pattern from `UserSights/` to `Output/`

The output path picker still lets users point it wherever they want (including directly at the game's `UserSights` folder if they prefer). This just changes the default.