### PR TITLE
build: self-contained single-file publish with compression

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-2022
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
-      contents: read
+      contents: write
       id-token: write
       attestations: write
     steps:
@@ -58,7 +58,7 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
-          dotnet-quality: 'ga'
+          dotnet-quality: 'preview'
 
       - name: Restore
         shell: pwsh
@@ -84,7 +84,7 @@ jobs:
             exit 1
           }
           $size = (Get-Item $exe).Length
-          Write-Host "✓ Build verification passed: FCS.exe ($([math]::Round($size/1KB, 2)) KB)"
+          Write-Host "✓ Build verification passed: FCS.exe ($([math]::Round($size/1MB, 2)) MB)"
 
       - name: Package ZIP
         shell: pwsh
@@ -116,3 +116,13 @@ jobs:
             dist/*.sha256
           if-no-files-found: error
           retention-days: 7
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: WT-FCSGenerator ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: dist/*.zip

--- a/src/FCS.csproj
+++ b/src/FCS.csproj
@@ -13,10 +13,11 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>
   </PropertyGroup>
-  <!-- Publish as a single-file, framework-dependent executable for Windows x64 (Release only) -->
+  <!-- Publish as a self-contained, compressed single-file executable for Windows x64 (Release only) -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <PublishSingleFile>true</PublishSingleFile>
-    <SelfContained>false</SelfContained>
+    <SelfContained>true</SelfContained>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <!-- Copy runtime asset folders to both build and publish outputs -->


### PR DESCRIPTION
## Summary

Switches the .NET publish from framework-dependent to self-contained, so users don't need to install the .NET runtime separately. The executable is compressed into a single file (~49 MB, ~45 MB zipped).

## Changes

### `src/FCS.csproj`
- `SelfContained`: `false` → `true`
- Added `EnableCompressionInSingleFile=true` for compression (~49 MB vs ~111 MB uncompressed)
- Trimming is not supported with WinForms (`NETSDK1175`), so this is the best we can achieve

### `.github/workflows/release.yml`
- `dotnet-quality`: `'ga'` → `'preview'` (.NET 10 is still preview)
- `contents` permission: `read` → `write` (needed for release creation)
- Verify step: shows size in MB instead of KB
- **Added GitHub Release creation** via `softprops/action-gh-release@v2` — auto-creates a GitHub Release with the ZIP attached when a `v*` tag is pushed

## Size comparison
| Build type | FCS.exe | ZIP |
|---|---|---|
| Framework-dependent (before) | ~0.6 MB | ~2 MB |
| Self-contained, no compression | ~111 MB | ~50 MB |
| **Self-contained + SingleFile + compression** | **~49 MB** | **~45 MB** |

Closes #39