### PR TITLE
ci: split release workflow into build + publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,13 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # ── Job 1: Build, package, and attest ──────────────────────────────
   build:
-    name: Build and package (Windows)
+    name: Build and package
     runs-on: windows-2022
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
-      contents: write
+      contents: read
       id-token: write
       attestations: write
     steps:
@@ -68,7 +69,7 @@ jobs:
       - name: Publish (win-x64, Release)
         shell: pwsh
         run: |
-          $pub = Join-Path $env:RUNNER_TEMP "publish\"
+          $pub = Join-Path $env:RUNNER_TEMP "publish"
           dotnet publish ./src/FCS.csproj -c Release -r win-x64 --no-restore -p:PublishDir="$pub"
 
           if (!(Test-Path $pub)) { Write-Error "Publish output not found at $pub"; exit 1 }
@@ -96,7 +97,6 @@ jobs:
           $zipName = "WT-FCSGenerator-$tag-win-x64.zip"
           $zipPath = Join-Path $dist $zipName
 
-          # Compress publish output directly
           Compress-Archive -Path (Join-Path $env:PUBLISH_DIR "*") -DestinationPath $zipPath -Force
 
           $zipSize = (Get-Item $zipPath).Length
@@ -107,21 +107,33 @@ jobs:
         with:
           subject-path: 'dist/*.zip'
 
-      - name: Upload release artifacts
+      - name: Upload release assets
         uses: actions/upload-artifact@v4
         with:
           name: release-assets
-          path: |
-            dist/*.zip
-            dist/*.sha256
+          path: dist/*.zip
           if-no-files-found: error
           retention-days: 7
+
+  # ── Job 2: Create GitHub Release (only after build succeeds) ───────
+  release:
+    name: Publish GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@v4
+        with:
+          name: release-assets
+          path: dist
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          name: WT-FCSGenerator ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           draft: false
           prerelease: false
           generate_release_notes: true


### PR DESCRIPTION
## Summary

Restructures the release workflow into two jobs so it works correctly with **immutable releases** enabled.

## Problem

With immutable releases, you can't create a release and then attach assets after the fact — the release is locked the moment it's published. The old single-job workflow created the release in the same job that built the assets, but if the release step ran before the ZIP was fully ready (or if something went wrong), you'd end up in a bad state.

## Solution

Split into two jobs with a dependency:

```
build (windows-2022)          release (ubuntu-latest)
  validate tag                    ↑
  validate VERSION                │ needs: build
  build + publish                 │
  package ZIP                     │
  attest provenance (SLSA)        │
  upload artifact ────────────────┘
                                download artifact
                                create GitHub Release + attach ZIP
```

The `release` job only runs after `build` succeeds completely. The GitHub Release is created in one shot with the ZIP already downloaded — no race condition, no partial releases.

## Changes

- **Build job**: `contents: read` (was `write`, only needs read for checkout + attestation)
- **Release job** (new): `contents: write`, runs on `ubuntu-latest` (cheap, fast — just downloads artifact and calls the API)
- Removed stale `dist/*.sha256` from artifact paths
- `generate_release_notes: true` for auto-generated changelogs from merged PRs

## Verification flow

Anyone can verify the ZIP was built from this repo:
```
gh attestation verify WT-FCSGenerator-v*.zip --owner tsvl
```

Closes #15