### PR TITLE
fix(ui): prevent button lockout, fix Luch nation filter and timer, restrict dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Luch and Luch Lite sights now respect nation selection instead of generating for all nations.
+- Generate button no longer stays disabled after early validation failures (missing `fcsgen` tool or game path).
+- Generate button is disabled during generation to prevent overlapping jobs.
+- Timer no longer shows `infinity:NaN` for Luch and Luch Lite sights (`IsRuning` flag was not being reset).
+- Removed dead commented-out code in Luch and Luch Lite generation blocks.
+
+### Changed
+
+- Sight type and language dropdowns now reject free-text input (dropdown-list only).
+
 ## [2.2.0] - 2026-02-20
 
 ### Added

--- a/src/Form1.Designer.cs
+++ b/src/Form1.Designer.cs
@@ -121,6 +121,7 @@ namespace FCS
             // comboBox1
             //
             comboBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F);
+            comboBox1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             comboBox1.FormattingEnabled = true;
             comboBox1.Items.AddRange(new object[] { "Tochka-SM2", "Duga", "Duga-2", "Luch", "Luch Lite", "Sector" });
             comboBox1.Location = new System.Drawing.Point(4, 93);
@@ -128,12 +129,12 @@ namespace FCS
             comboBox1.Name = "comboBox1";
             comboBox1.Size = new System.Drawing.Size(281, 21);
             comboBox1.TabIndex = 5;
-            comboBox1.Text = "Sight type";
             comboBox1.SelectedIndexChanged += ComboBox1_SelectedIndexChanged;
             //
             // comboBox2
             //
             comboBox2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F);
+            comboBox2.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             comboBox2.FormattingEnabled = true;
             comboBox2.Items.AddRange(new object[] { "English", "French", "Italian", "German", "Spanish", "Russian", "Polish", "Czech", "Turkish", "Chinese", "Japanese", "Portuguese", "Ukrainian", "Serbian", "Hungarian", "Korean", "Belarusian", "Romanian", "TChinese", "HChinese" });
             comboBox2.Location = new System.Drawing.Point(4, 68);

--- a/src/Form1.cs
+++ b/src/Form1.cs
@@ -512,13 +512,16 @@ namespace FCS
 
         private void Button2_Click(object sender, EventArgs e)
         {
+            button2.Enabled = false;
+
             // --- Input validation ---
             string sightType = comboBox1.Text;
-            if (sightType == "Sight type" || comboBox1.SelectedIndex < 0)
+            if (comboBox1.SelectedIndex < 0)
             {
                 MessageBox.Show(
                     "Please select a sight type before generating sights.",
                     "No Sight Type", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                button2.Enabled = true;
                 return;
             }
 
@@ -532,6 +535,7 @@ namespace FCS
                     "fcsgen.exe not found at:\n" + toolPath +
                     "\n\nPlace the fcsgen binary in the tools/ subfolder next to FCS.exe.",
                     "Tool Not Found", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                button2.Enabled = true;
                 return;
             }
 
@@ -543,6 +547,7 @@ namespace FCS
                     "aces.vromfs.bin not found at:\n" + acesBin +
                     "\n\nMake sure the path points to the War Thunder installation directory.",
                     "Game Not Found", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                button2.Enabled = true;
                 return;
             }
 
@@ -577,6 +582,7 @@ namespace FCS
                     progressBar1.Style = ProgressBarStyle.Blocks;
                     progressBar1.Value = 0;
                     SpeedNumbers = 0;
+                    button2.Enabled = true;
                     return;
                 }
             }
@@ -591,6 +597,7 @@ namespace FCS
                 progressBar1.Style = ProgressBarStyle.Blocks;
                 progressBar1.Value = 0;
                 SpeedNumbers = 0;
+                button2.Enabled = true;
                 return;
             }
 
@@ -2281,11 +2288,26 @@ namespace FCS
                 }
                 foreach (string file in file_list)
                 {
-                    label1.Text = Path.GetFileNameWithoutExtension(file);
-                    label1.Refresh();
-                    string TankPath2 = sightOutputBase + "//" + Path.GetFileNameWithoutExtension(file);
-                    //if (Directory.Exists(TankPath2) == false)
+                    progressBar1.PerformStep();
+                    string Country = Path.GetFileNameWithoutExtension(file).Split('_')[0];
+                    bool MakeSight = false;
+                    foreach (object itemChecked in checkedListBox2.CheckedItems)
                     {
+                        if (itemChecked.ToString().Contains("USA").Equals(true) && Country == "us") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("Germany").Equals(true) && Country == "germ") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("USSR").Equals(true) && Country == "ussr") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("Britain").Equals(true) && Country == "uk") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("Japan").Equals(true) && Country == "jp") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("China").Equals(true) && Country == "cn") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("Italy").Equals(true) && Country == "it") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("France").Equals(true) && Country == "fr") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("Sweden").Equals(true) && Country == "sw") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("Israel").Equals(true) && Country == "il") { MakeSight = true; }
+                    }
+                    if (MakeSight == true)
+                    {
+                        label1.Text = Path.GetFileNameWithoutExtension(file);
+                        label1.Refresh();
                         double ZoomIn = 0;
                         double ZoomOut = 0;
                         string BulletName = null;
@@ -2300,7 +2322,6 @@ namespace FCS
                         double RocketArmorPower = 0;
                         string ExplosiveType = null;
                         double ArmorPower = 0;
-                        progressBar1.PerformStep();
                         string TankData = null;
                         using (System.IO.StreamReader sr = new System.IO.StreamReader(file))
                         {
@@ -2587,14 +2608,11 @@ namespace FCS
                             }
                         }
                     }
-                    /*else
-                    {
-                        progressBar1.PerformStep();
-                    }*/
                 }
-                label1.Text = "";
+                label1.Text = "File: ";
                 label1.Refresh();
                 progressBar1.Value = 0;
+                IsRuning = false;
             }
             if (comboBox1.Text == "Luch Lite")
             {
@@ -2605,8 +2623,23 @@ namespace FCS
                 progressBar1.Step = 1;
                 foreach (string file in file_list)
                 {
-                    string TankPath2 = sightOutputBase + "//" + Path.GetFileNameWithoutExtension(file);
-                    //if (Directory.Exists(TankPath2) == false)
+                    progressBar1.PerformStep();
+                    string Country = Path.GetFileNameWithoutExtension(file).Split('_')[0];
+                    bool MakeSight = false;
+                    foreach (object itemChecked in checkedListBox2.CheckedItems)
+                    {
+                        if (itemChecked.ToString().Contains("USA").Equals(true) && Country == "us") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("Germany").Equals(true) && Country == "germ") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("USSR").Equals(true) && Country == "ussr") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("Britain").Equals(true) && Country == "uk") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("Japan").Equals(true) && Country == "jp") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("China").Equals(true) && Country == "cn") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("Italy").Equals(true) && Country == "it") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("France").Equals(true) && Country == "fr") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("Sweden").Equals(true) && Country == "sw") { MakeSight = true; }
+                        if (itemChecked.ToString().Contains("Israel").Equals(true) && Country == "il") { MakeSight = true; }
+                    }
+                    if (MakeSight == true)
                     {
                         label1.Text = Path.GetFileNameWithoutExtension(file);
                         label1.Refresh();
@@ -2618,7 +2651,6 @@ namespace FCS
                         double BallisticCaliber = 0;
                         double Speed = 0;
                         double Cx = 0;
-                        progressBar1.PerformStep();
                         string TankData = null;
                         using (System.IO.StreamReader sr = new System.IO.StreamReader(file))
                         {
@@ -2713,14 +2745,11 @@ namespace FCS
                             }
                         }
                     }
-                    /*else
-                    {
-                        progressBar1.PerformStep();
-                    }*/
                 }
-                label1.Text = "";
+                label1.Text = "File: ";
                 label1.Refresh();
                 progressBar1.Value = 0;
+                IsRuning = false;
             }
             if (comboBox1.Text == "Duga")
             {
@@ -3544,6 +3573,9 @@ namespace FCS
                 progressBar1.Value = 0;
                 IsRuning = false;
             }
+
+            IsRuning = false;
+            button2.Enabled = true;
         }
 
         private void ComboBox1_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
## Summary

Fixes several UI issues in the generation workflow: the Generate button could be clicked multiple times causing interleaved jobs, it stayed permanently disabled after certain validation failures, Luch/Luch Lite ignored nation selection and left the timer in an `infinity:NaN` state, and the sight type / language combo boxes allowed arbitrary text input.

## Changes

### Generate button state management
- Disable `button2` at the start of `Button2_Click` to prevent re-entrant clicks
- Re-enable on **all** early-return paths: sight type not selected, `fcsgen.exe` not found, `aces.vromfs.bin` not found, pipeline failure, and exception handler
- Add final safety-net `IsRuning = false` + `button2.Enabled = true` at method end

### Luch / Luch Lite nation filtering
- Add the same `Country` / `MakeSight` / `checkedListBox2` gate that Tochka-SM2, Duga, Duga-2, and Sector already use
- Sights are now generated only for checked nations, matching the behavior of every other sight type

### Timer fix
- Set `IsRuning = false` at the end of the Luch and Luch Lite blocks so `timer1_Tick` stops updating the elapsed/remaining labels (previously showed `infinity:NaN`)

### Combo box input restriction
- Set `DropDownStyle = DropDownList` on both `comboBox1` (sight type) and `comboBox2` (language) so users can only pick from predefined values
- Removed the stale `comboBox1.Text = "Sight type"` placeholder (incompatible with `DropDownList`; validation uses `SelectedIndex < 0` instead)

### Dead code removal
- Removed commented-out `//if (Directory.Exists(...))` blocks and `/*else { progressBar1.PerformStep(); }*/` remnants in Luch and Luch Lite sections

## Checklist

- [x] Builds cleanly (`dotnet build`)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Small, focused scope