### PR TITLE
docs: add docs/temp/ as gitignored scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -463,3 +463,6 @@ assets/Datamine/aces.vromfs.bin_u/gamedata/weapons/groundmodels_weapons/*
 assets/Datamine/.fcsgen-version\nassets/Datamine/lang.vromfs.bin_u/lang/*\n!assets/Datamine/lang.vromfs.bin_u/lang/.gitkeep
 
 tools/fcsgen/test_data/output/*
+
+# Temporary docs that don't need to be checked in
+docs/temp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ tools/fcsgen/          Rust workspace — datamine extraction + ballistic comput
   core/                Library crate (parsing, conversion, ballistic math)
 assets/                Runtime data (localization CSVs, ignore list, generated intermediates)
 docs/                  Architecture docs, format specs, sight family notes
+  temp/                Scratch/working docs (gitignored — never committed)
 ```
 
 **Important:** `src/` is exclusively C#/.NET. `tools/fcsgen/` is exclusively Rust. Don't look for Rust code in `src/` or C# code in `tools/`.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -44,6 +44,7 @@ docs/                       Documentation
   datamine-to-data.md       Extraction rules reference (stage 1)
   sights.md                 Sight family summaries
   stage3-form1-core.md      Reverse-engineering notes for stage 3 rewrite
+  temp/                     Scratch/working docs (gitignored — never committed)
 ```
 
 ## Pipeline architecture


### PR DESCRIPTION
Add `docs/temp/` as a gitignored scratch directory for temporary/working documents that don't need to be committed.

- Added `docs/temp/` to `.gitignore`
- Documented the directory in `AGENTS.md` and `docs/overview.md` repo layout trees